### PR TITLE
refactor: migrate to qbcore framework

### DIFF
--- a/myDj/client.lua
+++ b/myDj/client.lua
@@ -1,19 +1,22 @@
-ESX = exports["es_extended"]:getSharedObject()
+local QBCore = exports['qb-core']:GetCoreObject()
 
 xSound = exports.xsound
 
-if Config.useESX then
-   Citizen.CreateThread(function()
-      --[[   while ESX == nil do
-            TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-            Citizen.Wait(0)
-        end
+local PlayerData = {}
 
-        Citizen.Wait(100)]]
+if Config.useQB then
+    PlayerData = QBCore.Functions.GetPlayerData()
 
-        -- sync
+    RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
+        PlayerData = QBCore.Functions.GetPlayerData()
+    end)
 
-        ESX.TriggerServerCallback('myDJ:receiveRunningSongs', function(DJPositions)
+    RegisterNetEvent('QBCore:Client:OnJobUpdate', function(job)
+        PlayerData.job = job
+    end)
+
+    Citizen.CreateThread(function()
+        QBCore.Functions.TriggerCallback('myDJ:receiveRunningSongs', function(DJPositions)
         
             if DJPositions ~= nil then
                 for k, v in pairs(DJPositions) do
@@ -76,7 +79,7 @@ Citizen.CreateThread(function()
         isNearDJ = false
 
         for k, v in pairs(Config.DJPositions) do
-            if (not Config.useESX or v.requiredJob == nil or ESX ~= nil and ESX.PlayerData.job ~= nil and ESX.PlayerData.job.name == v.requiredJob) then
+            if (not Config.useQB or v.requiredJob == nil or PlayerData.job ~= nil and PlayerData.job.name == v.requiredJob) then
                 local distance = Vdist(playerCoords, v.pos.x, v.pos.y, v.pos.z)
 
                 if distance < 2.0 then
@@ -128,7 +131,7 @@ Citizen.CreateThread(function()
                 SetNuiFocus(true, true)
                 isDjOpen = true
                 SendNUIMessage({type = 'open'})
-                ESX.TriggerServerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
+                QBCore.Functions.TriggerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
                     SendNUIMessage({type = 'getPlaylists', playlists = playlists, songs = songs})
                 end)
             end
@@ -143,7 +146,7 @@ AddEventHandler('myDj:open', function()
     SetNuiFocus(true, true)
     isDjOpen = true
     SendNUIMessage({type = 'open'})
-    ESX.TriggerServerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
+    QBCore.Functions.TriggerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
         SendNUIMessage({type = 'getPlaylists', playlists = playlists, songs = songs})
     end)
 end)
@@ -268,7 +271,7 @@ function volumeDown(DJName)
 end
 
 function playTitleFromPlaylist(DJName, DJPos, DJRange, link, playlistId)
-    ESX.TriggerServerCallback('myDJ:requestPlaylistById', function(playlistSongs)
+    QBCore.Functions.TriggerCallback('myDJ:requestPlaylistById', function(playlistSongs)
 		if playlistSongs ~= nil then
 			for k, v in pairs(playlistSongs) do
 				if v.link == link then
@@ -318,7 +321,7 @@ if Config.enableCommand then
         SetNuiFocus(true, true)
         isDjOpen = true
         SendNUIMessage({type = 'open'})
-        ESX.TriggerServerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
+        QBCore.Functions.TriggerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
             SendNUIMessage({type = 'getPlaylists', playlists = playlists, songs = songs})
         end)
     end, false)
@@ -429,7 +432,7 @@ RegisterNUICallback('addSongToPlaylist', function(data, cb)
     --TriggerServerEvent('myDJ:addSongToPlaylist', 1, 'data.link')
 
     Wait(100)
-    ESX.TriggerServerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
+    QBCore.Functions.TriggerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
         SendNUIMessage({type = 'getPlaylists', playlists = playlists, songs = songs})
     end)
 end)

--- a/myDj/config.lua
+++ b/myDj/config.lua
@@ -15,7 +15,7 @@ Translation = {
 
 Config.Locale = 'en'
 
-Config.useESX = true -- can not be disabled without changing the callbacks
+Config.useQB = true -- can not be disabled without changing the callbacks
 Config.enableCommand = false
 
 Config.enableMarker = true -- purple marker at the DJ stations

--- a/myDj/fxmanifest.lua
+++ b/myDj/fxmanifest.lua
@@ -1,48 +1,43 @@
 fx_version 'bodacious'
 game 'gta5'
-shared_script '@es_extended/imports.lua'
 
+shared_script '@qb-core/shared.lua'
 
 client_scripts {
-	'@NativeUI/NativeUI.lua',
-	'config.lua',
-	'client.lua',
+    '@NativeUI/NativeUI.lua',
+    'config.lua',
+    'client.lua',
 }
 
 server_scripts {
-	'@mysql-async/lib/MySQL.lua',
-	'config.lua',
-	'server.lua',
+    '@mysql-async/lib/MySQL.lua',
+    'config.lua',
+    'server.lua',
 }
 
 ui_page 'html/index.html'
 
 files {
     'html/index.html',
-	
-	'html/css/style.css',
-	'html/css/fontawesome.css',
-	
-	'html/img/*.png',
-	
-	'html/js/script.js',
-	'html/js/jquery-3.5.1.min.js',
+    'html/css/style.css',
+    'html/css/fontawesome.css',
+    'html/img/*.png',
+    'html/js/script.js',
+    'html/js/jquery-3.5.1.min.js',
+    'html/webfonts/Icons/fa-brands-400.eot',
+    'html/webfonts/Icons/fa-brands-400.svg',
+    'html/webfonts/Icons/fa-brands-400.tff',
+    'html/webfonts/Icons/fa-brands-400.woff',
+    'html/webfonts/Icons/fa-brands-400.woff2',
+    'html/webfonts/Icons/fa-regular-400.eot',
+    'html/webfonts/Icons/fa-regular-400.svg',
+    'html/webfonts/Icons/fa-regular-400.tff',
+    'html/webfonts/Icons/fa-regular-400.woff',
+    'html/webfonts/Icons/fa-regular-400.woff2',
+    'html/webfonts/Icons/fa-solid-900.eot',
+    'html/webfonts/Icons/fa-solid-900.svg',
+    'html/webfonts/Icons/fa-solid-900.tff',
+    'html/webfonts/Icons/fa-solid-900.woff',
+    'html/webfonts/Icons/fa-solid-900.woff2',
+}
 
-	'html/webfonts/Icons/fa-brands-400.eot',
-	'html/webfonts/Icons/fa-brands-400.svg',
-	'html/webfonts/Icons/fa-brands-400.tff',
-	'html/webfonts/Icons/fa-brands-400.woff',
-	'html/webfonts/Icons/fa-brands-400.woff2',
-  
-	'html/webfonts/Icons/fa-regular-400.eot',
-	'html/webfonts/Icons/fa-regular-400.svg',
-	'html/webfonts/Icons/fa-regular-400.tff',
-	'html/webfonts/Icons/fa-regular-400.woff',
-	'html/webfonts/Icons/fa-regular-400.woff2',
-  
-	'html/webfonts/Icons/fa-solid-900.eot',
-	'html/webfonts/Icons/fa-solid-900.svg',
-	'html/webfonts/Icons/fa-solid-900.tff',
-	'html/webfonts/Icons/fa-solid-900.woff',
-	'html/webfonts/Icons/fa-solid-900.woff2',
-}server_scripts { '@mysql-async/lib/MySQL.lua' }

--- a/myDj/server.lua
+++ b/myDj/server.lua
@@ -1,6 +1,6 @@
-ESX = exports["es_extended"]:getSharedObject()
+local QBCore = exports['qb-core']:GetCoreObject()
 
-ESX.RegisterServerCallback('myDJ:requestPlaylistsAndSongs', function(source, cb)
+QBCore.Functions.CreateCallback('myDJ:requestPlaylistsAndSongs', function(source, cb)
 
     local playlists = {}
     local songs = {}
@@ -19,7 +19,7 @@ ESX.RegisterServerCallback('myDJ:requestPlaylistsAndSongs', function(source, cb)
     )
 end)
 
-ESX.RegisterServerCallback('myDJ:requestPlaylistById', function(source, cb, playlistId)
+QBCore.Functions.CreateCallback('myDJ:requestPlaylistById', function(source, cb, playlistId)
 
 	MySQL.Async.fetchAll('SELECT * from playlist_songs WHERE playlist = @playlistId', {
 		['@playlistId'] = playlistId,
@@ -30,7 +30,7 @@ ESX.RegisterServerCallback('myDJ:requestPlaylistById', function(source, cb, play
 	)
 end)
 
-ESX.RegisterServerCallback('myDJ:requestPlaylists', function(source, cb)
+QBCore.Functions.CreateCallback('myDJ:requestPlaylists', function(source, cb)
     MySQL.Async.fetchAll('SELECT id, label from playlists', {},
     function(result)
         cb(result)
@@ -38,7 +38,7 @@ ESX.RegisterServerCallback('myDJ:requestPlaylists', function(source, cb)
     )
 end)
 
-ESX.RegisterServerCallback('myDJ:requestPlaylistSongs', function(source, cb, playlistId)
+QBCore.Functions.CreateCallback('myDJ:requestPlaylistSongs', function(source, cb, playlistId)
     MySQL.Async.fetchAll('SELECT * from playlist_songs WHERE playlist = @playlist', {
         ['@playlistId'] = playlistId,
     },
@@ -48,7 +48,7 @@ ESX.RegisterServerCallback('myDJ:requestPlaylistSongs', function(source, cb, pla
     )
 end)
 
-ESX.RegisterServerCallback('myDJ:receiveRunningSongs', function(source, cb)
+QBCore.Functions.CreateCallback('myDJ:receiveRunningSongs', function(source, cb)
     cb(Config.DJPositions)
 end)
 


### PR DESCRIPTION
## Summary
- replace ESX with QBCore in client and server scripts
- update configuration and manifest for QBCore

## Testing
- ⚠️ `luac -p client.lua server.lua config.lua` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a27b7039448326951264450248cc1f