### PR TITLE
refactor: replace ox inventory with qb-inventory

### DIFF
--- a/ars_ambulancejob/README.md
+++ b/ars_ambulancejob/README.md
@@ -9,7 +9,7 @@ Experience the intensity of emergency response in Arius Ambulance Job :ambulance
 
 :dart: **Dependencies**
 
--   ox_inventory
+-   qb-inventory
 -   ox_target / qb-target
 
 :loudspeaker: **Features:**

--- a/ars_ambulancejob/client/injuries.lua
+++ b/ars_ambulancejob/client/injuries.lua
@@ -17,10 +17,10 @@ local function checkInjuryCause(cause)
 
     utils.debug(item, cause)
 
-    local count = exports.ox_inventory:Search('count', item)
+    local count = utils.getItemCount(item)
     if count < 1 then return utils.showNotification(locale("not_enough_" .. item)) end
 
-    local itemDurability = utils.getItem(item)?.metadata?.durability
+    local itemDurability = utils.getItem(item)?.info?.quality
 
     if itemDurability then
         if itemDurability < Config.ConsumeItemPerUse then

--- a/ars_ambulancejob/client/job/job.lua
+++ b/ars_ambulancejob/client/job/job.lua
@@ -69,11 +69,10 @@ local function checkPatient(target)
             icon = 'medkit',
             iconColor = "#5BC0DE",
             onSelect = function()
-                local count = exports.ox_inventory:Search('count', "defibrillator")
+                local count = utils.getItemCount("defibrillator")
                 if count < 1 then return utils.showNotification(locale("not_enough_defibrillator")) end
 
-
-                local itemDurability = utils.getItem("defibrillator")?.metadata?.durability
+                local itemDurability = utils.getItem("defibrillator")?.info?.quality
 
                 if itemDurability then
                     if itemDurability < Config.ConsumeItemPerUse then return utils.showNotification(locale("no_durability")) end

--- a/ars_ambulancejob/client/job/medical_bag.lua
+++ b/ars_ambulancejob/client/job/medical_bag.lua
@@ -14,7 +14,8 @@ local function openMedicalBag()
     TaskStartScenarioInPlace(playerPed, "CODE_HUMAN_MEDIC_TEND_TO_DEAD")
 
     lib.callback('ars_ambulancejob:openMedicalBag', false, function(stash)
-        exports.ox_inventory:openInventory("stash", stash)
+        TriggerServerEvent('inventory:server:OpenInventory', 'stash', stash, {maxweight = 50 * 1000, slots = 10})
+        TriggerEvent('inventory:client:SetCurrentStash', stash)
     end)
 end
 

--- a/ars_ambulancejob/client/job/shops.lua
+++ b/ars_ambulancejob/client/job/shops.lua
@@ -33,7 +33,8 @@ local function createShops()
                         DrawMarker(2, self.coords.x, self.coords.y, self.coords.z, 0.0, 0.0, 0.0, 0.0, 180.0, 0.0, 1.0, 1.0, 1.0, 200, 20, 20, 50, false, true, 2, false, nil, nil, false)
 
                         if self.currentDistance < 1 and IsControlJustReleased(0, 38) then
-                            exports.ox_inventory:openInventory("shop", { type = name })
+                            TriggerServerEvent('inventory:server:OpenInventory', 'shop', name, pharmacy.items)
+                            TriggerEvent('inventory:client:SetCurrentStash', name)
                         end
                     end
                 end

--- a/ars_ambulancejob/client/job/stashes.lua
+++ b/ars_ambulancejob/client/job/stashes.lua
@@ -19,15 +19,14 @@ local function createStashes()
                 end,
                 nearby = function(self)
                     if hasJob(Config.EmsJobs) then
-                        DrawMarker(2, self.coords.x, self.coords.y, self.coords.z, 0.0, 0.0, 0.0, 180.0, 0.0, 0.0, 0.2,
-                            0.2, 0.2, 199, 208, 209, 100, true, true, 2, nil, nil, false)
+                        DrawMarker(2, self.coords.x, self.coords.y, self.coords.z, 0.0, 0.0, 0.0, 180.0, 0.0, 0.0, 0.2, 0.2, 0.2, 199, 208, 209, 100, true, true, 2, nil, nil, false)
 
                         if IsControlJustReleased(0, 38) then
-                            exports.ox_inventory:openInventory('stash', id)
+                            TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, {maxweight = stash.weight * 1000, slots = stash.slots})
+                            TriggerEvent('inventory:client:SetCurrentStash', id)
                         end
                     end
-                end
-
+                end,
             })
         end
     end

--- a/ars_ambulancejob/client/modules/utils.lua
+++ b/ars_ambulancejob/client/modules/utils.lua
@@ -16,6 +16,7 @@ local EndTextCommandSetBlipName = EndTextCommandSetBlipName
 local GetEntityCoords = GetEntityCoords
 local PlayerPedId = PlayerPedId
 local TriggerServerEvent = TriggerServerEvent
+local QBCore = exports['qb-core']:GetCoreObject()
 
 utils = {}
 peds = {}
@@ -104,10 +105,16 @@ function utils.getClosestHospital()
 end
 
 function utils.addRemoveItem(type, item, quantity)
-    local data = {}
-    data.toggle = type == "remove"
-    data.item = item
-    data.quantity = quantity
+    if item == 'money' then
+        TriggerServerEvent('ars_ambulancejob:addRemoveMoney', type ~= 'remove', quantity)
+        return
+    end
+
+    local data = {
+        toggle = type == 'remove',
+        item = item,
+        quantity = quantity
+    }
 
     utils.debug(type, item, quantity)
     utils.debug(data)
@@ -126,6 +133,19 @@ function utils.getItem(name)
     local item = lib.callback.await('ars_ambulancejob:getItem', false, name)
 
     return item
+end
+
+function utils.getItemCount(name)
+    local count = 0
+    local items = QBCore.Functions.GetPlayerData().items or {}
+
+    for _, v in pairs(items) do
+        if v.name == name then
+            count = count + (v.amount or 0)
+        end
+    end
+
+    return count
 end
 
 function utils.isBedOccupied(coords)

--- a/ars_ambulancejob/client/paramedic.lua
+++ b/ars_ambulancejob/client/paramedic.lua
@@ -8,6 +8,7 @@ local SetEntityHeading   = SetEntityHeading
 local SetEntityHealth    = SetEntityHealth
 local TaskPlayAnim       = TaskPlayAnim
 local Wait               = Wait
+local QBCore            = exports['qb-core']:GetCoreObject()
 
 
 local function openParamedicMenu(ped, hospital)
@@ -18,7 +19,7 @@ local function openParamedicMenu(ped, hospital)
             {
                 title = locale("get_treated_paramedic"),
                 onSelect = function()
-                    local money = exports.ox_inventory:Search("count", "money")
+                    local money = QBCore.Functions.GetPlayerData().money and QBCore.Functions.GetPlayerData().money.cash or 0
 
                     if money >= Config.ParamedicTreatmentPrice then
                         utils.addRemoveItem("remove", "money", Config.ParamedicTreatmentPrice)


### PR DESCRIPTION
## Summary
- swap ox_inventory dependency for qb-inventory
- add QBCore inventory helpers and money handling
- open shops and stashes using qb-inventory events

## Testing
- `luacheck client/job/shops.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2a83857c48326b5c972e045298ede