### PR TITLE
Fix ambulance job inventory integration and vehicle keys

### DIFF
--- a/ars_ambulancejob/client/job/garage.lua
+++ b/ars_ambulancejob/client/job/garage.lua
@@ -4,6 +4,7 @@ local SetModelAsNoLongerNeeded = SetModelAsNoLongerNeeded
 local NetworkFadeInEntity      = NetworkFadeInEntity
 local TaskEnterVehicle         = TaskEnterVehicle
 local GetPedInVehicleSeat      = GetPedInVehicleSeat
+local GetVehicleNumberPlateText = GetVehicleNumberPlateText
 local IsControlJustReleased    = IsControlJustReleased
 local TaskLeaveVehicle         = TaskLeaveVehicle
 local FreezeEntityPosition     = FreezeEntityPosition
@@ -42,6 +43,10 @@ local function openCarList(garage)
                     lib.setVehicleProperties(vehicle, v.modifications)
 
                     TaskEnterVehicle(playerPed, vehicle, -1, -1, 1.0, 1, 0)
+                    local plate = GetVehicleNumberPlateText(vehicle)
+                    TriggerEvent('vehiclekeys:client:SetOwner', plate)
+                    TriggerEvent('qb-vehiclekeys:client:GiveKeys', plate)
+                    TriggerServerEvent('qb-vehiclekeys:server:AcquireVehicleKeys', plate)
                 end
             })
         end

--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -1,6 +1,7 @@
 QBCore = exports['qb-core']:GetCoreObject()
 PlayerData = nil
 local hotbarShown = false
+local CurrentStash
 
 -- Handlers
 
@@ -21,6 +22,11 @@ end)
 
 RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
     PlayerData = val
+end)
+
+-- Legacy support: allow other resources to track the opened stash
+RegisterNetEvent('inventory:client:SetCurrentStash', function(stash)
+    CurrentStash = stash
 end)
 
 AddEventHandler('onResourceStart', function(resourceName)

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -150,6 +150,21 @@ RegisterNetEvent('qb-inventory:server:openVending', function(data)
     OpenShop(src, 'vending')
 end)
 
+-- Compatibility event for resources using legacy inventory triggers
+RegisterNetEvent('inventory:server:OpenInventory', function(invType, id, data)
+    local src = source
+    if invType == 'shop' then
+        if type(data) == 'table' then
+            CreateShop({ name = id, label = id, items = data })
+        end
+        OpenShop(src, id)
+    elseif invType == 'otherplayer' then
+        OpenInventoryById(src, id)
+    else
+        OpenInventory(src, id, data)
+    end
+end)
+
 RegisterNetEvent('qb-inventory:server:closeInventory', function(inventory)
     local src = source
     local QBPlayer = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
## Summary
- Add legacy `inventory:server:OpenInventory` event so other resources like ambulance job can open stashes and shops
- Expose `inventory:client:SetCurrentStash` for compatibility with scripts expecting stash tracking
- Give spawned EMS vehicles keys using qb-vehiclekeys

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c226bf3883268b8e6354a0bf1902