### PR TITLE
fix stash reopen and bossmenu qb-target

### DIFF
--- a/ars_ambulancejob/client/bridge/target.lua
+++ b/ars_ambulancejob/client/bridge/target.lua
@@ -172,7 +172,19 @@ elseif GetResourceState('qb-target') == 'started' then
             }
         end
 
-        exports['qb-target']:AddBoxZone("name" .. coords, coords, 1.5, 1.6, {}, { options = options })
+        -- Build a unique zone name based on coordinates to avoid collisions
+        local zoneName = string.format('box_zone_%s_%s_%s', coords.x, coords.y, coords.z)
+
+        exports['qb-target']:AddBoxZone(zoneName, coords, 1.5, 1.6, {
+            name = zoneName,
+            heading = 0,
+            debugPoly = false,
+            minZ = coords.z - 1.0,
+            maxZ = coords.z + 1.0
+        }, {
+            options = options,
+            distance = 2.0
+        })
     end
 
     function addGlobalPlayer(_options)

--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -636,7 +636,9 @@ function OpenInventory(source, identifier, data)
 
     local inventory = Inventories[identifier]
 
-    if inventory and inventory.isOpen then
+    -- Allow the same player to re-open a stash even if the inventory state wasn't
+    -- properly cleared on close. Only block other players from accessing it.
+    if inventory and inventory.isOpen and inventory.isOpen ~= source then
         TriggerClientEvent('QBCore:Notify', source, 'This inventory is currently in use', 'error')
         return
     end


### PR DESCRIPTION
## Summary
- allow re-opening a stash by the same player without triggering "inventory in use"
- fix qb-target bossmenu zone with proper name and bounds

## Testing
- `lua -v` *(fails: command not found)*
- `luac -p qb-inventory/server/functions.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68a2cd02e4608326ace084083be35f84