### PR TITLE
feat(inventory): persist stash items and allow bank purchases

### DIFF
--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -125,6 +125,20 @@ end
 
 exports('SaveInventory', SaveInventory)
 
+-- Persists a stash's contents to the database.
+--- @param identifier string The stash identifier
+function SaveStash(identifier)
+    local stash = Inventories[identifier]
+    if not stash then return end
+    MySQL.prepare('INSERT INTO inventories (identifier, items) VALUES (?, ?) ON DUPLICATE KEY UPDATE items = ?', {
+        identifier,
+        json.encode(stash.items),
+        json.encode(stash.items)
+    })
+end
+
+exports('SaveStash', SaveStash)
+
 -- Sets the items in a inventory.
 --- @param identifier string The identifier of the player or inventory.
 --- @param items table The items to set in the inventory.


### PR DESCRIPTION
## Summary
- ensure stashes save to the database immediately
- allow shop purchases to debit from either cash or bank
- save inventories after item transfers to prevent loss

## Testing
- `luacheck qb-inventory/server/functions.lua qb-inventory/server/main.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a39355c604832699c842b20483b13d