### PR TITLE
feat(inventory): persist stashes and improve item transfers

### DIFF
--- a/qb-inventory/client/drops.lua
+++ b/qb-inventory/client/drops.lua
@@ -93,9 +93,10 @@ RegisterNUICallback('DropItem', function(item, cb)
         if dropId then
             while not NetworkDoesNetworkIdExist(dropId) do Wait(10) end
             local bag = NetworkGetEntityFromNetworkId(dropId)
-            SetModelAsNoLongerNeeded(bag)
+            SetEntityAsMissionEntity(bag, true, false)
             PlaceObjectOnGroundProperly(bag)
             FreezeEntityPosition(bag, true)
+            SetModelAsNoLongerNeeded(Config.ItemDropObject)
             local newDropId = 'drop-' .. dropId
             cb(newDropId)
         else

--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -304,6 +304,20 @@ RegisterNUICallback('SetInventoryData', function(data, cb)
 end)
 
 RegisterNUICallback('GiveItem', function(data, cb)
+    local targetId = tonumber(data.plyXd)
+    if targetId then
+        local item = data.ItemInfoFullHd or data.item
+        local amount = data.NumberOfItem or data.amount
+        local slot = item and (item.slot or data.slot)
+        local info = item and (item.info or data.info)
+        if item and amount and slot then
+            QBCore.Functions.TriggerCallback('qb-inventory:server:giveItem', function(success)
+                cb(success)
+            end, targetId, item.name, amount, slot, info)
+            return
+        end
+    end
+
     local player, distance = QBCore.Functions.GetClosestPlayer(GetEntityCoords(PlayerPedId()))
     if player ~= -1 and distance < 3 then
         local playerId = GetPlayerServerId(player)

--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -125,6 +125,20 @@ end
 
 exports('SaveInventory', SaveInventory)
 
+-- Persists a stash's contents to the database.
+--- @param identifier string The stash identifier
+function SaveStash(identifier)
+    local stash = Inventories[identifier]
+    if not stash then return end
+    MySQL.prepare('INSERT INTO inventories (identifier, items) VALUES (?, ?) ON DUPLICATE KEY UPDATE items = ?', {
+        identifier,
+        json.encode(stash.items),
+        json.encode(stash.items)
+    })
+end
+
+exports('SaveStash', SaveStash)
+
 -- Sets the items in a inventory.
 --- @param identifier string The identifier of the player or inventory.
 --- @param items table The items to set in the inventory.


### PR DESCRIPTION
## Summary
- ensure stashes save to the database immediately
- allow shop purchases to debit from either cash or bank
- save inventories after item transfers to prevent loss
- make dropped items visible and persistent
- allow giving items directly to a specified ID

## Testing
- `luacheck qb-inventory/client/main.lua qb-inventory/client/drops.lua qb-inventory/server/main.lua qb-inventory/server/functions.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `luac -p qb-inventory/client/main.lua qb-inventory/client/drops.lua qb-inventory/server/main.lua qb-inventory/server/functions.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a39355c604832699c842b20483b13d