### PR TITLE
feat: enable drop and vending without qb-target

### DIFF
--- a/qb-inventory/README.md
+++ b/qb-inventory/README.md
@@ -10,6 +10,8 @@
 - Weapon Attachments
 - Shops
 - Item Drops
+- Optional targetless item drop interaction (use `[E]`/`[G]` prompts when `Config.UseTarget` is false)
+- Optional targetless vending (use `[E]` prompts when `Config.UseTarget` is false)
 
 ## Documentation
 https://docs.qbcore.org/qbcore-documentation/qbcore-resources/qb-inventory

--- a/qb-inventory/client/drops.lua
+++ b/qb-inventory/client/drops.lua
@@ -2,8 +2,57 @@ HoldingDrop = false
 local bagObject = nil
 local heldDrop = nil
 CurrentDrop = nil
+local ActiveDrops = {}
 
 -- Functions
+
+local function trackDrop(id, bag)
+    if Config.UseTarget then
+        exports['qb-target']:AddTargetEntity(bag, {
+            options = {
+                {
+                    icon = 'fas fa-backpack',
+                    label = Lang:t('menu.o_bag'),
+                    action = function()
+                        TriggerServerEvent('qb-inventory:server:openDrop', id)
+                        CurrentDrop = id
+                    end,
+                },
+                {
+                    icon = 'fas fa-hand-pointer',
+                    label = 'Pick up bag',
+                    action = function()
+                        if IsPedArmed(PlayerPedId(), 4) then
+                            return QBCore.Functions.Notify('You can not be holding a Gun and a Bag!', 'error', 5500)
+                        end
+                        if HoldingDrop then
+                            return QBCore.Functions.Notify('Your already holding a bag, Go Drop it!', 'error', 5500)
+                        end
+                        AttachEntityToEntity(
+                            bag,
+                            PlayerPedId(),
+                            GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
+                            Config.ItemDropObjectOffset[1].x,
+                            Config.ItemDropObjectOffset[1].y,
+                            Config.ItemDropObjectOffset[1].z,
+                            Config.ItemDropObjectOffset[2].x,
+                            Config.ItemDropObjectOffset[2].y,
+                            Config.ItemDropObjectOffset[2].z,
+                            true, true, false, true, 1, true
+                        )
+                        bagObject = bag
+                        HoldingDrop = true
+                        heldDrop = id
+                        exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    end,
+                }
+            },
+            distance = 2.5,
+        })
+    else
+        ActiveDrops[id] = bag
+    end
+end
 
 function GetDrops()
     QBCore.Functions.TriggerCallback('qb-inventory:server:GetCurrentDrops', function(drops)
@@ -11,19 +60,7 @@ function GetDrops()
         for k, v in pairs(drops) do
             local bag = NetworkGetEntityFromNetworkId(v.entityId)
             if DoesEntityExist(bag) then
-                exports['qb-target']:AddTargetEntity(bag, {
-                    options = {
-                        {
-                            icon = 'fas fa-backpack',
-                            label = Lang:t('menu.o_bag'),
-                            action = function()
-                                TriggerServerEvent('qb-inventory:server:openDrop', k)
-                                CurrentDrop = k
-                            end,
-                        },
-                    },
-                    distance = 2.5,
-                })
+                trackDrop(k, bag)
             end
         end
     end)
@@ -35,7 +72,11 @@ RegisterNetEvent('qb-inventory:client:removeDropTarget', function(dropId)
     while not NetworkDoesNetworkIdExist(dropId) do Wait(10) end
     local bag = NetworkGetEntityFromNetworkId(dropId)
     while not DoesEntityExist(bag) do Wait(10) end
-    exports['qb-target']:RemoveTargetEntity(bag)
+    if Config.UseTarget then
+        exports['qb-target']:RemoveTargetEntity(bag)
+    else
+        ActiveDrops['drop-' .. dropId] = nil
+    end
 end)
 
 RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
@@ -43,47 +84,7 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
     local bag = NetworkGetEntityFromNetworkId(dropId)
     while not DoesEntityExist(bag) do Wait(10) end
     local newDropId = 'drop-' .. dropId
-    exports['qb-target']:AddTargetEntity(bag, {
-        options = {
-            {
-                icon = 'fas fa-backpack',
-                label = Lang:t('menu.o_bag'),
-                action = function()
-                    TriggerServerEvent('qb-inventory:server:openDrop', newDropId)
-                    CurrentDrop = newDropId
-                end,
-            },
-            {
-                icon = 'fas fa-hand-pointer',
-                label = 'Pick up bag',
-                action = function()
-                    if IsPedArmed(PlayerPedId(), 4) then
-                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500)
-                    end
-                    if HoldingDrop then
-                        return QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)
-                    end
-                    AttachEntityToEntity(
-                        bag,
-                        PlayerPedId(),
-                        GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
-                        Config.ItemDropObjectOffset[1].x,
-                        Config.ItemDropObjectOffset[1].y,
-                        Config.ItemDropObjectOffset[1].z,
-                        Config.ItemDropObjectOffset[2].x,
-                        Config.ItemDropObjectOffset[2].y,
-                        Config.ItemDropObjectOffset[2].z,
-                        true, true, false, true, 1, true
-                    )
-                    bagObject = bag
-                    HoldingDrop = true
-                    heldDrop = newDropId
-                    exports['qb-core']:DrawText('Press [G] to drop the bag')
-                end,
-            }
-        },
-        distance = 2.5,
-    })
+    trackDrop(newDropId, bag)
 end)
 
 -- NUI Callbacks
@@ -107,9 +108,27 @@ end)
 
 -- Thread
 
+local function getClosestDrop()
+    local ped = PlayerPedId()
+    local pos = GetEntityCoords(ped)
+    for id, bag in pairs(ActiveDrops) do
+        if DoesEntityExist(bag) then
+            local dist = #(pos - GetEntityCoords(bag))
+            if dist <= 1.5 then
+                return id, bag
+            end
+        else
+            ActiveDrops[id] = nil
+        end
+    end
+    return nil
+end
+
 CreateThread(function()
     while true do
+        local idle = 1000
         if HoldingDrop then
+            idle = 0
             if IsControlJustPressed(0, 47) then
                 DetachEntity(bagObject, true, true)
                 local coords = GetEntityCoords(PlayerPedId())
@@ -123,7 +142,43 @@ CreateThread(function()
                 bagObject = nil
                 heldDrop = nil
             end
+        elseif not Config.UseTarget then
+            local id, bag = getClosestDrop()
+            if id and bag then
+                idle = 0
+                exports['qb-core']:DrawText('[E] ' .. Lang:t('menu.o_bag') .. ' / [G] Pick up bag')
+                if IsControlJustPressed(0, 38) then
+                    TriggerServerEvent('qb-inventory:server:openDrop', id)
+                    CurrentDrop = id
+                    exports['qb-core']:HideText()
+                elseif IsControlJustPressed(0, 47) then
+                    if IsPedArmed(PlayerPedId(), 4) then
+                        QBCore.Functions.Notify('You can not be holding a Gun and a Bag!', 'error', 5500)
+                    elseif HoldingDrop then
+                        QBCore.Functions.Notify('Your already holding a bag, Go Drop it!', 'error', 5500)
+                    else
+                        AttachEntityToEntity(
+                            bag,
+                            PlayerPedId(),
+                            GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
+                            Config.ItemDropObjectOffset[1].x,
+                            Config.ItemDropObjectOffset[1].y,
+                            Config.ItemDropObjectOffset[1].z,
+                            Config.ItemDropObjectOffset[2].x,
+                            Config.ItemDropObjectOffset[2].y,
+                            Config.ItemDropObjectOffset[2].z,
+                            true, true, false, true, 1, true
+                        )
+                        bagObject = bag
+                        HoldingDrop = true
+                        heldDrop = id
+                        exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    end
+                end
+            else
+                exports['qb-core']:HideText()
+            end
         end
-        Wait(0)
+        Wait(idle)
     end
 end)

--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -376,17 +376,42 @@ end)
 -- Vending
 
 CreateThread(function()
-    exports['qb-target']:AddTargetModel(Config.VendingObjects, {
-        options = {
-            {
-                type = 'server',
-                event = 'qb-inventory:server:openVending',
-                icon = 'fa-solid fa-cash-register',
-                label = Lang:t('menu.vending'),
+    if Config.UseTarget then
+        exports['qb-target']:AddTargetModel(Config.VendingObjects, {
+            options = {
+                {
+                    type = 'server',
+                    event = 'qb-inventory:server:openVending',
+                    icon = 'fa-solid fa-cash-register',
+                    label = Lang:t('menu.vending'),
+                },
             },
-        },
-        distance = 2.5
-    })
+            distance = 2.5
+        })
+    else
+        while true do
+            local idle = 1000
+            local ped = PlayerPedId()
+            local coords = GetEntityCoords(ped)
+            for _, model in ipairs(Config.VendingObjects) do
+                local object = GetClosestObjectOfType(coords.x, coords.y, coords.z, 1.5, joaat(model), false, false, false)
+                if object ~= 0 then
+                    idle = 0
+                    exports['qb-core']:DrawText('[E] ' .. Lang:t('menu.vending'))
+                    if IsControlJustPressed(0, 38) then
+                        TriggerServerEvent('qb-inventory:server:openVending', { coords = GetEntityCoords(object) })
+                        exports['qb-core']:HideText()
+                        Wait(1000)
+                    end
+                    break
+                end
+            end
+            if idle ~= 0 then
+                exports['qb-core']:HideText()
+            end
+            Wait(idle)
+        end
+    end
 end)
 
 -- Commands


### PR DESCRIPTION
## Summary
- allow dropped bags and vending machines to be used without `qb-target`
- document targetless drops and vending

## Testing
- `luacheck .` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `luac -p client/main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dbd591a48326a2a1b863f5c03e00