### PR TITLE
feat: enable drop, vending and stash interactions without qb-target

### DIFF
--- a/qb-inventory/README.md
+++ b/qb-inventory/README.md
@@ -10,6 +10,12 @@
 - Weapon Attachments
 - Shops
 - Item Drops
+- Optional targetless item drop interaction (use `[E]`/`[G]` prompts when `Config.UseTarget` is false)
+- Optional targetless vending (use `[E]` prompts when `Config.UseTarget` is false)
+- Optional targetless stashes for configured props (use `[E]` prompts when `Config.UseTarget` is false; configure models in `Config.StashObjects`)
+- Shop purchases immediately add items to your inventory and display an item box
+- Dropping or giving items saves your inventory so they no longer persist after being moved
+- Inventory UI automatically refreshes while open when items are added or removed
 
 ## Documentation
 https://docs.qbcore.org/qbcore-documentation/qbcore-resources/qb-inventory

--- a/qb-inventory/client/drops.lua
+++ b/qb-inventory/client/drops.lua
@@ -2,8 +2,57 @@ HoldingDrop = false
 local bagObject = nil
 local heldDrop = nil
 CurrentDrop = nil
+local ActiveDrops = {}
 
 -- Functions
+
+local function trackDrop(id, bag)
+    if Config.UseTarget then
+        exports['qb-target']:AddTargetEntity(bag, {
+            options = {
+                {
+                    icon = 'fas fa-backpack',
+                    label = Lang:t('menu.o_bag'),
+                    action = function()
+                        TriggerServerEvent('qb-inventory:server:openDrop', id)
+                        CurrentDrop = id
+                    end,
+                },
+                {
+                    icon = 'fas fa-hand-pointer',
+                    label = 'Pick up bag',
+                    action = function()
+                        if IsPedArmed(PlayerPedId(), 4) then
+                            return QBCore.Functions.Notify('You can not be holding a Gun and a Bag!', 'error', 5500)
+                        end
+                        if HoldingDrop then
+                            return QBCore.Functions.Notify('Your already holding a bag, Go Drop it!', 'error', 5500)
+                        end
+                        AttachEntityToEntity(
+                            bag,
+                            PlayerPedId(),
+                            GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
+                            Config.ItemDropObjectOffset[1].x,
+                            Config.ItemDropObjectOffset[1].y,
+                            Config.ItemDropObjectOffset[1].z,
+                            Config.ItemDropObjectOffset[2].x,
+                            Config.ItemDropObjectOffset[2].y,
+                            Config.ItemDropObjectOffset[2].z,
+                            true, true, false, true, 1, true
+                        )
+                        bagObject = bag
+                        HoldingDrop = true
+                        heldDrop = id
+                        exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    end,
+                }
+            },
+            distance = 2.5,
+        })
+    else
+        ActiveDrops[id] = bag
+    end
+end
 
 function GetDrops()
     QBCore.Functions.TriggerCallback('qb-inventory:server:GetCurrentDrops', function(drops)
@@ -11,19 +60,7 @@ function GetDrops()
         for k, v in pairs(drops) do
             local bag = NetworkGetEntityFromNetworkId(v.entityId)
             if DoesEntityExist(bag) then
-                exports['qb-target']:AddTargetEntity(bag, {
-                    options = {
-                        {
-                            icon = 'fas fa-backpack',
-                            label = Lang:t('menu.o_bag'),
-                            action = function()
-                                TriggerServerEvent('qb-inventory:server:openDrop', k)
-                                CurrentDrop = k
-                            end,
-                        },
-                    },
-                    distance = 2.5,
-                })
+                trackDrop(k, bag)
             end
         end
     end)
@@ -35,7 +72,11 @@ RegisterNetEvent('qb-inventory:client:removeDropTarget', function(dropId)
     while not NetworkDoesNetworkIdExist(dropId) do Wait(10) end
     local bag = NetworkGetEntityFromNetworkId(dropId)
     while not DoesEntityExist(bag) do Wait(10) end
-    exports['qb-target']:RemoveTargetEntity(bag)
+    if Config.UseTarget then
+        exports['qb-target']:RemoveTargetEntity(bag)
+    else
+        ActiveDrops['drop-' .. dropId] = nil
+    end
 end)
 
 RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
@@ -43,47 +84,7 @@ RegisterNetEvent('qb-inventory:client:setupDropTarget', function(dropId)
     local bag = NetworkGetEntityFromNetworkId(dropId)
     while not DoesEntityExist(bag) do Wait(10) end
     local newDropId = 'drop-' .. dropId
-    exports['qb-target']:AddTargetEntity(bag, {
-        options = {
-            {
-                icon = 'fas fa-backpack',
-                label = Lang:t('menu.o_bag'),
-                action = function()
-                    TriggerServerEvent('qb-inventory:server:openDrop', newDropId)
-                    CurrentDrop = newDropId
-                end,
-            },
-            {
-                icon = 'fas fa-hand-pointer',
-                label = 'Pick up bag',
-                action = function()
-                    if IsPedArmed(PlayerPedId(), 4) then
-                        return QBCore.Functions.Notify("You can not be holding a Gun and a Bag!", "error", 5500)
-                    end
-                    if HoldingDrop then
-                        return QBCore.Functions.Notify("Your already holding a bag, Go Drop it!", "error", 5500)
-                    end
-                    AttachEntityToEntity(
-                        bag,
-                        PlayerPedId(),
-                        GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
-                        Config.ItemDropObjectOffset[1].x,
-                        Config.ItemDropObjectOffset[1].y,
-                        Config.ItemDropObjectOffset[1].z,
-                        Config.ItemDropObjectOffset[2].x,
-                        Config.ItemDropObjectOffset[2].y,
-                        Config.ItemDropObjectOffset[2].z,
-                        true, true, false, true, 1, true
-                    )
-                    bagObject = bag
-                    HoldingDrop = true
-                    heldDrop = newDropId
-                    exports['qb-core']:DrawText('Press [G] to drop the bag')
-                end,
-            }
-        },
-        distance = 2.5,
-    })
+    trackDrop(newDropId, bag)
 end)
 
 -- NUI Callbacks
@@ -107,9 +108,27 @@ end)
 
 -- Thread
 
+local function getClosestDrop()
+    local ped = PlayerPedId()
+    local pos = GetEntityCoords(ped)
+    for id, bag in pairs(ActiveDrops) do
+        if DoesEntityExist(bag) then
+            local dist = #(pos - GetEntityCoords(bag))
+            if dist <= 1.5 then
+                return id, bag
+            end
+        else
+            ActiveDrops[id] = nil
+        end
+    end
+    return nil
+end
+
 CreateThread(function()
     while true do
+        local idle = 1000
         if HoldingDrop then
+            idle = 0
             if IsControlJustPressed(0, 47) then
                 DetachEntity(bagObject, true, true)
                 local coords = GetEntityCoords(PlayerPedId())
@@ -123,7 +142,43 @@ CreateThread(function()
                 bagObject = nil
                 heldDrop = nil
             end
+        elseif not Config.UseTarget then
+            local id, bag = getClosestDrop()
+            if id and bag then
+                idle = 0
+                exports['qb-core']:DrawText('[E] ' .. Lang:t('menu.o_bag') .. ' / [G] Pick up bag')
+                if IsControlJustPressed(0, 38) then
+                    TriggerServerEvent('qb-inventory:server:openDrop', id)
+                    CurrentDrop = id
+                    exports['qb-core']:HideText()
+                elseif IsControlJustPressed(0, 47) then
+                    if IsPedArmed(PlayerPedId(), 4) then
+                        QBCore.Functions.Notify('You can not be holding a Gun and a Bag!', 'error', 5500)
+                    elseif HoldingDrop then
+                        QBCore.Functions.Notify('Your already holding a bag, Go Drop it!', 'error', 5500)
+                    else
+                        AttachEntityToEntity(
+                            bag,
+                            PlayerPedId(),
+                            GetPedBoneIndex(PlayerPedId(), Config.ItemDropObjectBone),
+                            Config.ItemDropObjectOffset[1].x,
+                            Config.ItemDropObjectOffset[1].y,
+                            Config.ItemDropObjectOffset[1].z,
+                            Config.ItemDropObjectOffset[2].x,
+                            Config.ItemDropObjectOffset[2].y,
+                            Config.ItemDropObjectOffset[2].z,
+                            true, true, false, true, 1, true
+                        )
+                        bagObject = bag
+                        HoldingDrop = true
+                        heldDrop = id
+                        exports['qb-core']:DrawText('Press [G] to drop the bag')
+                    end
+                end
+            else
+                exports['qb-core']:HideText()
+            end
         end
-        Wait(0)
+        Wait(idle)
     end
 end)

--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -376,17 +376,98 @@ end)
 -- Vending
 
 CreateThread(function()
-    exports['qb-target']:AddTargetModel(Config.VendingObjects, {
-        options = {
-            {
-                type = 'server',
-                event = 'qb-inventory:server:openVending',
-                icon = 'fa-solid fa-cash-register',
-                label = Lang:t('menu.vending'),
+    if Config.UseTarget then
+        exports['qb-target']:AddTargetModel(Config.VendingObjects, {
+            options = {
+                {
+                    type = 'server',
+                    event = 'qb-inventory:server:openVending',
+                    icon = 'fa-solid fa-cash-register',
+                    label = Lang:t('menu.vending'),
+                },
             },
-        },
-        distance = 2.5
-    })
+            distance = 2.5
+        })
+    else
+        while true do
+            local idle = 1000
+            local ped = PlayerPedId()
+            local coords = GetEntityCoords(ped)
+            for _, model in ipairs(Config.VendingObjects) do
+                local object = GetClosestObjectOfType(coords.x, coords.y, coords.z, 1.5, joaat(model), false, false, false)
+                if object ~= 0 then
+                    idle = 0
+                    exports['qb-core']:DrawText('[E] ' .. Lang:t('menu.vending'))
+                    if IsControlJustPressed(0, 38) then
+                        TriggerServerEvent('qb-inventory:server:openVending', { coords = GetEntityCoords(object) })
+                        exports['qb-core']:HideText()
+                        Wait(1000)
+                    end
+                    break
+                end
+            end
+            if idle ~= 0 then
+                exports['qb-core']:HideText()
+            end
+            Wait(idle)
+        end
+    end
+end)
+
+-- Stashes
+
+CreateThread(function()
+    if not Config.StashObjects or #Config.StashObjects == 0 then return end
+    if Config.UseTarget then
+        exports['qb-target']:AddTargetModel(Config.StashObjects, {
+            options = {
+                {
+                    icon = 'fas fa-box-open',
+                    label = Lang:t('menu.stash'),
+                    action = function(entity)
+                        local coords = GetEntityCoords(entity)
+                        local model = GetEntityModel(entity)
+                        local id = string.format('stash-%s-%s-%s-%s', model, math.floor(coords.x), math.floor(coords.y), math.floor(coords.z))
+                        TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, {
+                            label = Lang:t('menu.stash'),
+                            slots = Config.StashSize.slots,
+                            maxweight = Config.StashSize.maxweight,
+                        })
+                    end,
+                },
+            },
+            distance = 2.5
+        })
+    else
+        while true do
+            local idle = 1000
+            local ped = PlayerPedId()
+            local coords = GetEntityCoords(ped)
+            for _, model in ipairs(Config.StashObjects) do
+                local object = GetClosestObjectOfType(coords.x, coords.y, coords.z, 1.5, joaat(model), false, false, false)
+                if object ~= 0 then
+                    idle = 0
+                    exports['qb-core']:DrawText('[E] ' .. Lang:t('menu.stash'))
+                    if IsControlJustPressed(0, 38) then
+                        local ocoords = GetEntityCoords(object)
+                        local id = string.format('stash-%s-%s-%s-%s', model, math.floor(ocoords.x), math.floor(ocoords.y), math.floor(ocoords.z))
+                        TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, {
+                            label = Lang:t('menu.stash'),
+                            slots = Config.StashSize.slots,
+                            maxweight = Config.StashSize.maxweight,
+                        })
+                        exports['qb-core']:HideText()
+                        Wait(1000)
+                    end
+                    break
+                end
+            end
+            if idle ~= 0 then
+                exports['qb-core']:HideText()
+            end
+            Wait(idle)
+        end
+    end
 end)
 
 -- Commands

--- a/qb-inventory/config/config.lua
+++ b/qb-inventory/config/config.lua
@@ -36,6 +36,11 @@ Config = {
         'prop_vend_coffe_01',
     },
 
+    StashObjects = {
+        'prop_cs_rub_box_01',
+        'prop_ld_suitcase_01',
+    },
+
     VendingItems = {
         { name = 'kurkakola',    price = 4, amount = 50 },
         { name = 'water_bottle', price = 4, amount = 50 },

--- a/qb-inventory/locales/cs.lua
+++ b/qb-inventory/locales/cs.lua
@@ -42,6 +42,7 @@ local Translations = {
         ['bin'] = 'Otevři kontejner',
         ['craft'] = 'Craft',
         ['o_bag'] = 'Otevři tašku',
+        ['stash'] = 'Otevřít úložiště',
     },
     interaction = {
         ['craft'] = '~g~E~w~ - Craft',

--- a/qb-inventory/locales/de.lua
+++ b/qb-inventory/locales/de.lua
@@ -42,6 +42,7 @@ local Translations = {
         ['bin'] = 'Müllcontainer öffnen',
         ['craft'] = 'Herstellen',
         ['o_bag'] = 'Tasche öffnen',
+        ['stash'] = 'Versteck öffnen',
     },
     interaction = {
         ['craft'] = '~g~E~w~ - Herstellen',

--- a/qb-inventory/locales/en.lua
+++ b/qb-inventory/locales/en.lua
@@ -42,6 +42,7 @@ local Translations = {
         ['bin'] = 'Open Dumpster',
         ['craft'] = 'Craft',
         ['o_bag'] = 'Open Bag',
+        ['stash'] = 'Open Stash',
     },
     interaction = {
         ['craft'] = '~g~E~w~ - Craft',

--- a/qb-inventory/locales/es.lua
+++ b/qb-inventory/locales/es.lua
@@ -42,6 +42,7 @@ local Translations = {
         ['bin'] = 'Abrir Contenedor de Basura',
         ['craft'] = 'Crear',
         ['o_bag'] = 'Abrir Bolsa',
+        ['stash'] = 'Abrir Alijo',
     },
     interaction = {
         ['craft'] = '~g~E~w~ - Fabricar',

--- a/qb-inventory/locales/nl.lua
+++ b/qb-inventory/locales/nl.lua
@@ -42,6 +42,7 @@ local Translations = {
         ['bin'] = 'Open Prullenbak',
         ['craft'] = 'Maak',
         ['o_bag'] = 'Open Tas',
+        ['stash'] = 'Stash openen',
     },
     interaction = {
         ['craft'] = '~g~E~w~ - Maken',

--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -821,6 +821,9 @@ function AddItem(identifier, item, amount, slot, info, reason)
         '**Reason:** ' .. addReason .. '\n' ..
         '**Resource:** ' .. resourceName
     )
+    if player and Player(identifier).state.inv_busy then
+        TriggerClientEvent('qb-inventory:client:updateInventory', identifier)
+    end
     return true
 end
 
@@ -908,6 +911,9 @@ function RemoveItem(identifier, item, amount, slot, reason)
         '**Reason:** ' .. removeReason .. '\n' ..
         '**Resource:** ' .. resourceName
     )
+    if player and Player(identifier).state.inv_busy then
+        TriggerClientEvent('qb-inventory:client:updateInventory', identifier)
+    end
     return true
 end
 

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -354,6 +354,10 @@ QBCore.Functions.CreateCallback('qb-inventory:server:createDrop', function(sourc
         else
             table.insert(Drops[newDropId].items, item)
         end
+        SaveInventory(src)
+        if Player(src).state.inv_busy then
+            TriggerClientEvent('qb-inventory:client:updateInventory', src)
+        end
         cb(dropId)
     else
         cb(false)
@@ -421,6 +425,11 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
     end
 
     AddItem(source, itemInfo.name, amount, nil, itemInfo.info, 'shop-purchase')
+    SaveInventory(source)
+    if Player(source).state.inv_busy then
+        TriggerClientEvent('qb-inventory:client:updateInventory', source)
+    end
+    TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items[itemInfo.name], 'add', amount)
     TriggerEvent('qb-shops:server:UpdateShopItems', shop, itemInfo, amount)
     cb(true)
 end)
@@ -478,9 +487,10 @@ QBCore.Functions.CreateCallback('qb-inventory:server:giveItem', function(source,
     TriggerClientEvent('qb-inventory:client:ItemBox', source, itemInfo, 'remove', giveAmount)
     TriggerClientEvent('qb-inventory:client:giveAnim', target)
     TriggerClientEvent('qb-inventory:client:ItemBox', target, itemInfo, 'add', giveAmount)
-    if Player(target).state.inv_busy then TriggerClientEvent('qb-inventory:client:updateInventory', target) end
     SaveInventory(source)
     SaveInventory(target)
+    if Player(source).state.inv_busy then TriggerClientEvent('qb-inventory:client:updateInventory', source) end
+    if Player(target).state.inv_busy then TriggerClientEvent('qb-inventory:client:updateInventory', target) end
     cb(true)
 end)
 


### PR DESCRIPTION
## Summary
- allow dropped bags and vending machines to be used without `qb-target`
- configure stash props that open via `qb-target` or `[E]` prompts when `Config.UseTarget` is false
- add locale entry for stash prompts
- save inventory after dropping or giving items and show an item box when purchasing from shops
- refresh the inventory UI after dropping, giving or buying items and whenever items are added or removed while the inventory is open

## Testing
- `luacheck .` *(fails: command not found)*
- `luac -p qb-inventory/client/main.lua qb-inventory/server/main.lua qb-inventory/config/config.lua qb-inventory/locales/en.lua qb-inventory/locales/es.lua qb-inventory/locales/de.lua qb-inventory/locales/nl.lua qb-inventory/locales/cs.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a3dbd591a48326a2a1b863f5c03e00