### PR TITLE
feat: improve inventory refresh and drop handling

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -303,6 +303,12 @@ RegisterNUICallback('SetInventoryData', function(data, cb)
     cb('ok')
 end)
 
+RegisterNUICallback('DropItem', function(data, cb)
+    QBCore.Functions.TriggerCallback('qb-inventory:server:createDrop', function(dropName)
+        cb(dropName)
+    end, data)
+end)
+
 RegisterNUICallback('GiveItem', function(data, cb)
     local targetId = tonumber(data.plyXd)
     if targetId then

--- a/qb-inventory/html/js/app.js
+++ b/qb-inventory/html/js/app.js
@@ -923,6 +923,25 @@ function optionSwitch($fromSlot, $toSlot, $fromInv, $toInv, $toAmount, toData, f
 		}
         }
         if (!isItemShop) {
+                if ($toInv.attr('data-inventory') == 0 || $toInv.attr('data-inventory') == '0') {
+                        var newDrop = null;
+                        var dropData = Object.assign({}, fromData, { fromSlot: $fromSlot });
+                        $.ajax({
+                                type: 'POST',
+                                url: 'https://qb-inventory/DropItem',
+                                data: JSON.stringify(dropData),
+                                contentType: 'application/json',
+                                async: false,
+                                success: function(result) {
+                                        newDrop = result;
+                                }
+                        });
+                        if (!newDrop) {
+                                InventoryError($toInv, $toSlot);
+                                return;
+                        }
+                        $('.other-inventory').attr('data-inventory', newDrop);
+                }
                 $.post(
                         'https://qb-inventory/SetInventoryData',
                         JSON.stringify({
@@ -1563,6 +1582,25 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
 			}
                         $.post('https://qb-inventory/PlayDropSound', JSON.stringify({}));
                         if (!isItemShop) {
+                                if ($toInv.attr('data-inventory') == 0 || $toInv.attr('data-inventory') == '0') {
+                                        var newDrop = null;
+                                        var dropData = Object.assign({}, fromData, { fromSlot: $fromSlot });
+                                        $.ajax({
+                                                type: 'POST',
+                                                url: 'https://qb-inventory/DropItem',
+                                                data: JSON.stringify(dropData),
+                                                contentType: 'application/json',
+                                                async: false,
+                                                success: function(result) {
+                                                        newDrop = result;
+                                                }
+                                        });
+                                        if (!newDrop) {
+                                                InventoryError($toInv, $toSlot);
+                                                return;
+                                        }
+                                        $('.other-inventory').attr('data-inventory', newDrop);
+                                }
                                 $.post(
                                         'https://qb-inventory/SetInventoryData',
                                         JSON.stringify({
@@ -1893,6 +1931,25 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
 						}
 					}
                                         if (!isItemShop) {
+                                                if ($toInv.attr('data-inventory') == 0 || $toInv.attr('data-inventory') == '0') {
+                                                        var newDrop = null;
+                                                        var dropData = Object.assign({}, fromData, { fromSlot: $fromSlot });
+                                                        $.ajax({
+                                                                type: 'POST',
+                                                                url: 'https://qb-inventory/DropItem',
+                                                                data: JSON.stringify(dropData),
+                                                                contentType: 'application/json',
+                                                                async: false,
+                                                                success: function(result) {
+                                                                        newDrop = result;
+                                                                }
+                                                        });
+                                                        if (!newDrop) {
+                                                                InventoryError($toInv, $toSlot);
+                                                                return;
+                                                        }
+                                                        $('.other-inventory').attr('data-inventory', newDrop);
+                                                }
                                                 $.post(
                                                         'https://qb-inventory/SetInventoryData',
                                                         JSON.stringify({
@@ -1931,6 +1988,25 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
 							);
 					}
                                         if (!isItemShop) {
+                                                if ($toInv.attr('data-inventory') == 0 || $toInv.attr('data-inventory') == '0') {
+                                                        var newDrop = null;
+                                                        var dropData = Object.assign({}, fromData, { fromSlot: $fromSlot });
+                                                        $.ajax({
+                                                                type: 'POST',
+                                                                url: 'https://qb-inventory/DropItem',
+                                                                data: JSON.stringify(dropData),
+                                                                contentType: 'application/json',
+                                                                async: false,
+                                                                success: function(result) {
+                                                                        newDrop = result;
+                                                                }
+                                                        });
+                                                        if (!newDrop) {
+                                                                InventoryError($toInv, $toSlot);
+                                                                return;
+                                                        }
+                                                        $('.other-inventory').attr('data-inventory', newDrop);
+                                                }
                                                 $.post(
                                                         'https://qb-inventory/SetInventoryData',
                                                         JSON.stringify({
@@ -2243,6 +2319,25 @@ function swap($fromSlot, $toSlot, $fromInv, $toInv, $toAmount) {
 				}
                                 $.post('https://qb-inventory/PlayDropSound', JSON.stringify({}));
                                 if (!isItemShop) {
+                                        if ($toInv.attr('data-inventory') == 0 || $toInv.attr('data-inventory') == '0') {
+                                                var newDrop = null;
+                                                var dropData = Object.assign({}, fromData, { fromSlot: $fromSlot });
+                                                $.ajax({
+                                                        type: 'POST',
+                                                        url: 'https://qb-inventory/DropItem',
+                                                        data: JSON.stringify(dropData),
+                                                        contentType: 'application/json',
+                                                        async: false,
+                                                        success: function(result) {
+                                                                newDrop = result;
+                                                        }
+                                                });
+                                                if (!newDrop) {
+                                                        InventoryError($toInv, $toSlot);
+                                                        return;
+                                                }
+                                                $('.other-inventory').attr('data-inventory', newDrop);
+                                        }
                                         $.post(
                                                 'https://qb-inventory/SetInventoryData',
                                                 JSON.stringify({

--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -615,8 +615,8 @@ exports('CreateShop', CreateShop)
 --- @param name string The identifier of the inventory to open.
 function OpenShop(source, name)
     if not name then return end
-    local Player = QBCore.Functions.GetPlayer(source)
-    if not Player then return end
+    local QBPlayer = QBCore.Functions.GetPlayer(source)
+    if not QBPlayer then return end
     if not RegisteredShops[name] then return end
     local playerPed = GetPlayerPed(source)
     local playerCoords = GetEntityCoords(playerPed)
@@ -634,7 +634,10 @@ function OpenShop(source, name)
         slots = #RegisteredShops[name].items,
         inventory = RegisteredShops[name].items
     }
-    TriggerClientEvent('qb-inventory:client:openInventory', source, Player.PlayerData.items, formattedInventory)
+    if Player(source) then
+        Player(source).state.inv_busy = true
+    end
+    TriggerClientEvent('qb-inventory:client:openInventory', source, QBPlayer.PlayerData.items, formattedInventory)
 end
 
 exports('OpenShop', OpenShop)

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -426,9 +426,7 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
 
     AddItem(source, itemInfo.name, amount, nil, itemInfo.info, 'shop-purchase')
     SaveInventory(source)
-    if Player(source).state.inv_busy then
-        TriggerClientEvent('qb-inventory:client:updateInventory', source)
-    end
+    TriggerClientEvent('qb-inventory:client:updateInventory', source)
     TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items[itemInfo.name], 'add', amount)
     TriggerEvent('qb-shops:server:UpdateShopItems', shop, itemInfo, amount)
     cb(true)
@@ -579,6 +577,7 @@ RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory,
                 end
             end
         end
+        TriggerClientEvent('qb-inventory:client:updateInventory', src)
 
         -- persist inventory changes
         if type(fromId) == 'number' then


### PR DESCRIPTION
## Summary
- create ground drop when items are dragged without a secondary inventory
- refresh player inventory after moves and purchases
- mark shops as busy when opened and expose drop creation callback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3fa0dc7ac8326a6e85e017af2f974