### PR TITLE
feat: add basic purchase handler

### DIFF
--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -634,6 +634,7 @@ function OpenShop(source, name)
         slots = #RegisteredShops[name].items,
         inventory = RegisteredShops[name].items
     }
+    -- mark player as busy to prevent overlapping inventory actions
     local pstate = (type(Player) == 'function' and Player(source) or nil)
     if pstate then pstate.state.inv_busy = true end
     TriggerClientEvent('qb-inventory:client:openInventory', source, QBPlayer.PlayerData.items, formattedInventory)

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -453,6 +453,17 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
     cb(true)
 end)
 
+RegisterNetEvent('qb-inventory:server:AttemptPurchase', function(itemName, amount, price, info, payWithBank)
+    local src = source
+    if not itemName or not amount or not price then return end
+    local QBPlayer = QBCore.Functions.GetPlayer(src)
+    if not QBPlayer then return end
+    local account = (payWithBank and 'bank' or 'cash')
+    if not QBPlayer.Functions.RemoveMoney(account, price * amount, 'shop-purchase') then return end
+    QBPlayer.Functions.AddItem(itemName, amount, false, info)
+    TriggerClientEvent('qb-inventory:client:updateInventory', src)
+end)
+
 QBCore.Functions.CreateCallback('qb-inventory:server:giveItem', function(source, cb, target, item, amount, slot, info)
     local player = QBCore.Functions.GetPlayer(source)
     if not player or player.PlayerData.metadata['isdead'] or player.PlayerData.metadata['inlaststand'] or player.PlayerData.metadata['ishandcuffed'] then


### PR DESCRIPTION
## Summary
- document inv_busy state when opening shops
- add `qb-inventory:server:AttemptPurchase` event to charge players and grant items

## Testing
- `luacheck server/main.lua server/functions.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a412f5a7fc83268dd0215b0a2c7b95