### PR TITLE
feat: optimize player inventory swap

### DIFF
--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -578,6 +578,20 @@ RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory,
     local QBPlayer = QBCore.Functions.GetPlayer(src)
     if not QBPlayer then return end
 
+    if fromInventory == 'player' and toInventory == 'player' and fromSlot ~= toSlot then
+        local items = QBPlayer.PlayerData.items
+        local a = items[fromSlot]
+        local b = items[toSlot]
+        if not a then return end
+        items[fromSlot] = b
+        items[toSlot] = a
+        if items[fromSlot] then items[fromSlot].slot = fromSlot end
+        if items[toSlot]   then items[toSlot].slot   = toSlot   end
+        QBPlayer.Functions.SetPlayerData('items', items)
+        TriggerClientEvent('qb-inventory:client:updateInventory', src)
+        return
+    end
+
     local fromItem = getItem(fromInventory, src, fromSlot)
     local toItem = getItem(toInventory, src, toSlot)
 


### PR DESCRIPTION
## Summary
- swap items directly when moving between player inventory slots to avoid unnecessary operations

## Testing
- ⚠️ `luac -p qb-inventory/server/main.lua` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4148429548326a692a101e77b4254