### PR TITLE
Validate account type and item name before removal

### DIFF
--- a/qb-inventory/server/functions.lua
+++ b/qb-inventory/server/functions.lua
@@ -840,7 +840,7 @@ exports('AddItem', AddItem)
 --- @param reason string - The reason for removing the item. Defaults to 'No reason specified' if not provided.
 --- @return boolean - Returns true if the item was successfully removed, false otherwise.
 function RemoveItem(identifier, item, amount, slot, reason)
-    if not QBCore.Shared.Items[item:lower()] then
+    if type(item) ~= 'string' or not QBCore.Shared.Items[item:lower()] then
         print('RemoveItem: Invalid item')
         return false
     end

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -453,6 +453,11 @@ QBCore.Functions.CreateCallback('qb-inventory:server:attemptPurchase', function(
         end
     end
 
+    if account ~= 'cash' and account ~= 'bank' then
+        cb(false)
+        return
+    end
+
     local removed = QBPlayer.Functions.RemoveMoney(account, price, 'shop-purchase')
     if not removed then
         cb(false)
@@ -472,6 +477,7 @@ RegisterNetEvent('qb-inventory:server:AttemptPurchase', function(itemName, amoun
     local QBPlayer = QBCore.Functions.GetPlayer(src)
     if not QBPlayer then return end
     local account = (payWithBank and 'bank' or 'cash')
+    if account ~= 'cash' and account ~= 'bank' then return end
     if not QBPlayer.Functions.RemoveMoney(account, price * amount, 'shop-purchase') then return end
     QBPlayer.Functions.AddItem(itemName, amount, false, info)
     TriggerClientEvent('qb-inventory:client:updateInventory', src)
@@ -609,6 +615,7 @@ RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory,
     local toItem = getItem(toInventory, src, toSlot)
 
     local function removeItem(identifier, itemName, amount, slot, reason)
+        if type(itemName) ~= 'string' then return false end
         if type(identifier) == 'number' then
             local player = identifier == src and QBPlayer or QBCore.Functions.GetPlayer(identifier)
             if player then


### PR DESCRIPTION
## Summary
- ensure only cash or bank accounts are charged in inventory purchase logic
- guard item removal calls to accept only string item names

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f1fbf874832694a753272cf96184