### PR TITLE
Add qb-inventory client wrapper for ox_inventory

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -1,4 +1,57 @@
 -- Client-side logic for the qb-inventory compatibility wrapper.
--- This file should map any qb-core inventory UI calls to ox_inventory.
+-- Maps common qb-core inventory calls to ox_inventory for compatibility.
 
--- Add client-side event handlers or helpers here as needed.
+local function normalize(items)
+    if not items then return {} end
+    local out = {}
+    if type(items) == 'string' then
+        out[#out+1] = { name = items, amount = 1 }
+        return out
+    end
+    if items.name then
+        out[#out+1] = { name = items.name, amount = items.amount or 1, metadata = items.info or items.metadata }
+        return out
+    end
+    for _, it in pairs(items) do
+        if type(it) == 'string' then
+            out[#out+1] = { name = it, amount = 1 }
+        elseif type(it) == 'table' then
+            out[#out+1] = { name = it.name or it[1], amount = it.amount or 1, metadata = it.info or it.metadata }
+        end
+    end
+    return out
+end
+
+-- Exports de cliente esperados por scripts QB
+exports('HasItem', function(items, amount, metadata)
+    local list = normalize(items)
+    local needed = amount or 1
+    for _, it in ipairs(list) do
+        local cnt = exports.ox_inventory:Search('count', string.lower(it.name), metadata or it.metadata)
+        if cnt >= (it.amount or needed) then
+            return true
+        end
+    end
+    return false
+end)
+
+exports('GetItem', function(name, metadata, returnSlots)
+    if returnSlots then
+        return exports.ox_inventory:Search('slots', string.lower(name), metadata)
+    end
+    return exports.ox_inventory:Search('count', string.lower(name), metadata)
+end)
+
+-- Stubs de UI de qb-inventory que algunos scripts llaman
+exports('ItemBox', function(...) end)
+exports('ShowHotbar', function(...) end)
+exports('HideHotbar', function(...) end)
+exports('CloseInventory', function()
+    TriggerEvent('ox_inventory:closeInventory')
+end)
+
+-- Abrir shop en cliente
+RegisterNetEvent('qb-inventory:client:OpenShop', function(id)
+    exports.ox_inventory:openInventory('shop', id)
+end)
+


### PR DESCRIPTION
## Summary
- map qb-inventory client calls to ox_inventory
- expose HasItem/GetItem exports and UI stubs

## Testing
- ⚠️ `luac -p qb-inventory/client/main.lua` (command not found)
- ⚠️ `apt-get update` (403 Repository not signed)


------
https://chatgpt.com/codex/tasks/task_e_68a69526a2ec832685333875e78d53f3