### PR TITLE
Update qb-inventory fxmanifest

### DIFF
--- a/qb-inventory/fxmanifest.lua
+++ b/qb-inventory/fxmanifest.lua
@@ -1,15 +1,20 @@
 fx_version 'cerulean'
 game 'gta5'
+lua54 'yes'
 
-name 'qb-inventory compatibility wrapper'
+name 'qb-inventory (compat for ox)'
+description 'Compatibility layer: exposes qb-inventory API using ox_inventory backend'
 version '1.0.0'
 
-description 'Compatibility layer for ox_inventory'
+shared_scripts {
+    '@qb-core/shared.lua'
+}
 
 client_scripts {
     'client/main.lua'
 }
 
 server_scripts {
+    '@oxmysql/lib/MySQL.lua',
     'server/main.lua'
 }


### PR DESCRIPTION
## Summary
- include qb-core shared script and oxmysql dependency in qb-inventory fxmanifest
- enable Lua 5.4 for compatibility layer

## Testing
- `luac -p qb-inventory/fxmanifest.lua` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6950d0f5c8326a8a7792b0b08c55b