### PR TITLE
Add qbgiveitem command wrapper

### DIFF
--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -218,3 +218,23 @@ RegisterNetEvent('qb-inventory:server:BuyItem', function(shopId, itemName, price
 
     TriggerClientEvent('QBCore:Notify', src, ('Compraste %s x%s'):format(itemName, count), 'success')
 end)
+-- Comando simple: /qbgiveitem [id] [item] [count]
+QBCore.Commands.Add('qbgiveitem', 'Dar ítem (wrapper ox)', {
+    {name='id', help='Player ID'},
+    {name='item', help='Item name'},
+    {name='count', help='Cantidad'}
+}, false, function(source, args)
+    local target = tonumber(args[1] or '')
+    local item   = args[2]
+    local count  = tonumber(args[3] or '1')
+    if not target or not item then
+        if source then
+            TriggerClientEvent('QBCore:Notify', source, 'Uso: /qbgiveitem [id] [item] [count]', 'error')
+        end
+        return
+    end
+    exports.ox_inventory:AddItem(target, string.lower(item), count or 1)
+    if source then
+        TriggerClientEvent('QBCore:Notify', source, ('Dado %s x%s a %s'):format(item, count or 1, target), 'success')
+    end
+end, 'admin')


### PR DESCRIPTION
## Summary
- add `/qbgiveitem` admin command as a simple wrapper to give items via ox inventory

## Testing
- `luacheck qb-inventory/server/main.lua` *(44 warnings, 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abf99240a083268238ce21148262e9