### PR TITLE
refactor: share normalize function

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -1,26 +1,7 @@
 ----------------------------------------------------------------
 -- qb-inventory (compat for ox) - CLIENT
 ----------------------------------------------------------------
-local function normalize(items)
-    if not items then return {} end
-    local out = {}
-    if type(items) == 'string' then
-        out[#out+1] = { name = items, amount = 1 }
-        return out
-    end
-    if items.name then
-        out[#out+1] = { name = items.name, amount = items.amount or 1, metadata = items.info or items.metadata }
-        return out
-    end
-    for _, it in pairs(items) do
-        if type(it) == 'string' then
-            out[#out+1] = { name = it, amount = 1 }
-        elseif type(it) == 'table' then
-            out[#out+1] = { name = it.name or it[1], amount = it.amount or 1, metadata = it.info or it.metadata }
-        end
-    end
-    return out
-end
+local normalize = require 'qb-inventory.shared.normalize'
 
 exports('HasItem', function(items, amount, metadata)
     local list = normalize(items)

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -4,26 +4,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
 -- =============== Utils ===============
-local function normalize(items)
-    if not items then return {} end
-    local out = {}
-    if type(items) == 'string' then
-        out[#out+1] = { name = items, amount = 1 }
-        return out
-    end
-    if items.name then
-        out[#out+1] = { name = items.name, amount = items.amount or 1, metadata = items.info or items.metadata }
-        return out
-    end
-    for _, it in pairs(items) do
-        if type(it) == 'string' then
-            out[#out+1] = { name = it, amount = 1 }
-        elseif type(it) == 'table' then
-            out[#out+1] = { name = it.name or it[1], amount = it.amount or 1, metadata = it.info or it.metadata }
-        end
-    end
-    return out
-end
+local normalize = require 'qb-inventory.shared.normalize'
 
 -- =============== Exports qb → ox ===============
 exports('AddItem', function(source, name, amount, metadata, slot)

--- a/qb-inventory/shared/normalize.lua
+++ b/qb-inventory/shared/normalize.lua
@@ -1,0 +1,22 @@
+local function normalize(items)
+    if not items then return {} end
+    local out = {}
+    if type(items) == 'string' then
+        out[#out+1] = { name = items, amount = 1 }
+        return out
+    end
+    if items.name then
+        out[#out+1] = { name = items.name, amount = items.amount or 1, metadata = items.info or items.metadata }
+        return out
+    end
+    for _, it in pairs(items) do
+        if type(it) == 'string' then
+            out[#out+1] = { name = it, amount = 1 }
+        elseif type(it) == 'table' then
+            out[#out+1] = { name = it.name or it[1], amount = it.amount or 1, metadata = it.info or it.metadata }
+        end
+    end
+    return out
+end
+
+return normalize


### PR DESCRIPTION
## Summary
- extract duplicated normalize logic into shared module
- use shared normalize function in client and server

## Testing
- `luac -p qb-inventory/shared/normalize.lua qb-inventory/client/main.lua qb-inventory/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac0b6a1cf08326985110d849e2e353