### PR TITLE
feat(qb-bridge): validate item metadata in HasItem

### DIFF
--- a/ox_inventory/modules/bridge/qb/client.lua
+++ b/ox_inventory/modules/bridge/qb/client.lua
@@ -75,7 +75,9 @@ export('qb-inventory.HasItem', function(items, amount)
 
     if type(items) == 'table' then
         for _, v in pairs(items) do
-            if Inventory.GetItemCount(v) < amount then
+            local name = v.name or v
+            local meta = v.metadata
+            if Inventory.GetItemCount(name, meta) < amount then
                 return false
             end
         end


### PR DESCRIPTION
## Summary
- validate metadata when checking items with `qb-inventory.HasItem`

## Testing
- `luacheck ox_inventory/modules/bridge/qb/client.lua` *(command not found)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b7831c883268cd812037128c8c9