### PR TITLE
Stop conflicting QB resources

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -26,7 +26,7 @@ AddEventHandler('QBCore:Server:OnGangUpdate', function(source, gang)
 end)
 
 AddEventHandler('onResourceStart', function(resource)
-    if resource ~= 'qb-weapons' or resource ~= 'qb-shops' then return end
+    if resource ~= 'qb-weapons' and resource ~= 'qb-shops' then return end
     StopResource(resource)
 end)
 


### PR DESCRIPTION
## Summary
- only block qb-weapons and qb-shops resources when they start

## Testing
- `lua5.4 - <<'EOF'
local events = {}
function AddEventHandler(name, cb) events[name]=cb end
function StopResource(resource) print('StopResource called with '..resource) end
AddEventHandler('onResourceStart', function(resource)
    if resource ~= 'qb-weapons' and resource ~= 'qb-shops' then return end
    StopResource(resource)
end)
print('Trigger qb-weapons:')
events['onResourceStart']('qb-weapons')
print('Trigger qb-shops:')
events['onResourceStart']('qb-shops')
print('Trigger other:')
events['onResourceStart']('other')
EOF`
- `luac5.4 -p ox_inventory/modules/bridge/qb/server.lua` *(fails: `luac5.4: ox_inventory/modules/bridge/qb/server.lua:212: 'then' expected near '?'`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b7c60e88326a5b41690f52d25f2