### PR TITLE
fix: return qb item fields from GetItem

### DIFF
--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -46,7 +46,11 @@ end)
 
 exports('GetItem', function(source, name, metadata)
     local slots = exports.ox_inventory:Search(source, 'slots', string.lower(name), metadata)
-    if slots and #slots > 0 then return slots[1] end
+    if slots and #slots > 0 then
+        slots[1].info = slots[1].metadata
+        slots[1].amount = slots[1].count
+        return slots[1]
+    end
     return nil
 end)
 


### PR DESCRIPTION
## Summary
- ensure `GetItem` converts `metadata` to `info` and `count` to `amount` for compatibility with qb scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0b7f3b348326aa6c1df2a3687d30