### PR TITLE
feat: support stash maxweight property

### DIFF
--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -94,7 +94,7 @@ RegisterNetEvent('inventory:server:OpenInventory', function(inventoryType, ident
             exports.ox_inventory:RegisterStash(
                 stashId, stashId,
                 (extraData and extraData.slots) or 50,
-                (extraData and extraData.weight) or 400000,
+                (extraData and (extraData.weight or extraData.maxweight)) or 400000,
                 extraData and extraData.owner,
                 extraData and extraData.groups
             )


### PR DESCRIPTION
## Summary
- honor `maxweight` when registering stashes so scripts like ars_ambulancejob can define stash capacity

## Testing
- `luac -p qb-inventory/server/main.lua`
- `lua /tmp/test_stash_weight.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac21f7300c8326b2f63470335d94ff