### PR TITLE
feat: track current stash state

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -3,6 +3,8 @@
 ----------------------------------------------------------------
 local normalize = require 'qb-inventory.shared.normalize'
 
+local currentStash
+
 exports('HasItem', function(items, amount, metadata)
     local list = normalize(items)
     local needed = amount or 1
@@ -35,10 +37,15 @@ exports('HideHotbar', function()
 end)
 exports('CloseInventory', function()
     TriggerEvent('ox_inventory:closeInventory')
+    currentStash = nil
 end)
 
 -- Abrir shop en cliente
 RegisterNetEvent('qb-inventory:client:OpenShop', function(id)
     exports.ox_inventory:openInventory('shop', id)
+end)
+
+RegisterNetEvent('inventory:client:SetCurrentStash', function(name)
+    currentStash = name
 end)
 ----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- track current stash name and reset when inventory closes
- allow other resources to set stash name via new event

## Testing
- `luac -p qb-inventory/client/main.lua`
- `luacheck qb-inventory/client/main.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2219631c8326941ff6e60d9c0d14