### PR TITLE
feat: export ItemBox and send detailed item info

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -20,11 +20,14 @@ exports('GetItem', function(name, metadata, returnSlots)
     return exports.ox_inventory:Search('count', string.lower(name), metadata)
 end)
 
-exports('ItemBox', function(items, type, amount)
+local function ItemBox(items, type, amount)
     for _, item in ipairs(normalize(items)) do
-        TriggerEvent('ox_inventory:itemNotify', { item, type, amount or item.amount })
+        local info = exports.ox_inventory:Items(item.name)
+        TriggerEvent('ox_inventory:itemNotify', { info, type, amount or item.amount })
     end
-end)
+end
+
+exports('ItemBox', ItemBox)
 
 exports('ShowHotbar', function()
     SendNUIMessage({ action = 'toggleHotbar', state = true })


### PR DESCRIPTION
## Summary
- export `ItemBox` to be used externally
- send full item data to `ox_inventory:itemNotify`

## Testing
- `luac -p qb-inventory/client/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac22496c848326b27e8f2204bed620