### PR TITLE
feat(qb): add item metadata from qb-core

### DIFF
--- a/ox_inventory/modules/bridge/qb/items_server.lua
+++ b/ox_inventory/modules/bridge/qb/items_server.lua
@@ -13,7 +13,11 @@ AddEventHandler('ox_inventory:itemList', function(ItemList)
                 weight      = tonumber(v.weight) or 0,
                 stack       = (v.unique == nil) and true or (not v.unique),
                 close       = true,
-                description = v.description
+                description = v.description,
+                image       = v.image,
+                client      = v.client,
+                server      = v.server,
+                consume     = v.consume
             }
         end
     end


### PR DESCRIPTION
## Summary
- expose `image`, `client`, `server`, and `consume` properties from qb-core items to ox_inventory

## Testing
- `luac -p modules/bridge/qb/items_server.lua`
- `restart ox_inventory` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac225db3488326adaaaf1b627bddd8