### PR TITLE
fix: register inventory normalizer as shared script

### DIFF
--- a/qb-inventory/client/main.lua
+++ b/qb-inventory/client/main.lua
@@ -1,7 +1,7 @@
 ----------------------------------------------------------------
 -- qb-inventory (compat for ox) - CLIENT
 ----------------------------------------------------------------
-local normalize = require 'qb-inventory.shared.normalize'
+local normalize = require 'shared.normalize'
 
 local currentStash
 

--- a/qb-inventory/fxmanifest.lua
+++ b/qb-inventory/fxmanifest.lua
@@ -7,7 +7,8 @@ description 'Compatibility layer: exposes qb-inventory API using ox_inventory ba
 version '1.0.0'
 
 shared_scripts {
-    '@qb-core/shared.lua'
+    '@qb-core/shared.lua',
+    'shared/normalize.lua'
 }
 
 client_scripts {

--- a/qb-inventory/server/main.lua
+++ b/qb-inventory/server/main.lua
@@ -4,7 +4,7 @@
 local QBCore = exports['qb-core']:GetCoreObject()
 
 -- =============== Utils ===============
-local normalize = require 'qb-inventory.shared.normalize'
+local normalize = require 'shared.normalize'
 
 -- Forward declarations
 local qbProductsToOx


### PR DESCRIPTION
## Summary
- add `shared/normalize.lua` to `qb-inventory` shared scripts
- require normalizer via relative path

## Testing
- `lua -e "package.path=package.path..';./qb-inventory/?.lua;./qb-inventory/?/?.lua'; local normalize=require('shared.normalize'); print('Loaded',type(normalize))"`
- `lua - <<'EOF'
package.path = package.path .. ';./qb-inventory/?.lua;./qb-inventory/?/?.lua'
exports = setmetatable({
  ox_inventory = {
    Search=function(...) return 1 end,
    Items=function(name) return { name=name } end
  }
}, { __call=function(t,name,fn) rawset(t,name,fn) end })
function RegisterNetEvent(...) end
function TriggerEvent(...) end
function SendNUIMessage(...) end
dofile('qb-inventory/client/main.lua')
print('client loaded')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68ac2adee6f48326b43119012ceee41a