### PR TITLE
Map QB item properties to ox_inventory

### DIFF
--- a/ox_inventory/modules/bridge/qb/items_server.lua
+++ b/ox_inventory/modules/bridge/qb/items_server.lua
@@ -12,12 +12,16 @@ AddEventHandler('ox_inventory:itemList', function(ItemList)
                 label       = v.label or lower,
                 weight      = tonumber(v.weight) or 0,
                 stack       = (v.unique == nil) and true or (not v.unique),
-                close       = true,
+                close       = v.shouldClose ~= false,
                 description = v.description,
                 image       = v.image,
                 client      = v.client,
                 server      = v.server,
-                consume     = v.consume
+                consume     = v.consume,
+                unique      = v.unique,
+                useable     = v.useable,
+                combinable  = v.combinable,
+                type        = v.type
             }
         end
     end


### PR DESCRIPTION
## Summary
- Preserve QB item attributes (unique, combinable, etc.) when generating the ox inventory item list
- Respect each item's `shouldClose` flag to control inventory closing

## Testing
- `lua <test script>` verifying `photo` keeps `close = false` and `clip_attachment` `close = true`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ee2b67483269bf4ca8329bdfdbe