### PR TITLE
fix: add ox inventory SaveInventory export for qb compatibility

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -269,6 +269,14 @@ export('qb-inventory.SaveInventory', function(playerId)
     Inventory.Save(playerId)
 end)
 
+export('ox_inventory.SaveInventory', function(playerId)
+    if type(playerId) ~= 'number' then
+        TypeError('playerId', 'number', type(playerId))
+    end
+
+    Inventory.Save(playerId)
+end)
+
 export('qb-inventory.SetInventory')
 export('qb-inventory.SetItemData')
 export('qb-inventory.UseItem')


### PR DESCRIPTION
## Summary
- expose `ox_inventory:SaveInventory` export to support `qb-core` saving

## Testing
- `luacheck ox_inventory/modules/bridge/qb/server.lua` *(fails: expected 'then' near '?')*


------
https://chatgpt.com/codex/tasks/task_e_68ac38ed3c9083268eeb5cb64ff457bb