### PR TITLE
Add stock to pharmacy items and ox inventory fallback

### DIFF
--- a/ars_ambulancejob/client/job/shops.lua
+++ b/ars_ambulancejob/client/job/shops.lua
@@ -33,8 +33,12 @@ local function createShops()
                         DrawMarker(2, self.coords.x, self.coords.y, self.coords.z, 0.0, 0.0, 0.0, 0.0, 180.0, 0.0, 1.0, 1.0, 1.0, 200, 20, 20, 50, false, true, 2, false, nil, nil, false)
 
                         if self.currentDistance < 1 and IsControlJustReleased(0, 38) then
-                            TriggerServerEvent('inventory:server:OpenInventory', 'shop', name, pharmacy.items)
-                            TriggerEvent('inventory:client:SetCurrentStash', name)
+                            if GetResourceState('ox_inventory') == 'started' then
+                                exports.ox_inventory:openInventory('shop', { id = name, items = pharmacy.items })
+                            else
+                                TriggerServerEvent('inventory:server:OpenInventory', 'shop', name, pharmacy.items)
+                                TriggerEvent('inventory:client:SetCurrentStash', name)
+                            end
                         end
                     end
                 end

--- a/ars_ambulancejob/config.lua
+++ b/ars_ambulancejob/config.lua
@@ -118,15 +118,15 @@ Config.Hospitals = {
 					pos = vector3(-462.8, -1014.48, 23.72),
 				},
 				items = {
-					{ name = 'medicalbag',    price = 50 },
-					{ name = 'bandage',       price = 50 },
-					{ name = 'defibrillator', price = 50 },
-					{ name = 'tweezers',      price = 50 },
-					{ name = 'burncream',     price = 50 },
-					{ name = 'suturekit',     price = 50 },
-					{ name = 'icepack',       price = 50 },
-				}
-			},
+                                        { name = 'medicalbag',    price = 50, amount = 50 },
+                                        { name = 'bandage',       price = 50, amount = 50 },
+                                        { name = 'defibrillator', price = 50, amount = 50 },
+                                        { name = 'tweezers',      price = 50, amount = 50 },
+                                        { name = 'burncream',     price = 50, amount = 50 },
+                                        { name = 'suturekit',     price = 50, amount = 50 },
+                                        { name = 'icepack',       price = 50, amount = 50 },
+                                }
+                        },
 			["ems_shop_2"] = {
 				job = false,
 				label = "Pharmacy",
@@ -140,11 +140,11 @@ Config.Hospitals = {
 					color = 2,
 					pos = vector3(-447.13, -1033.49, 23.8),
 				},
-				items = {
-					{ name = 'bandage', price = 50 },
-				}
-			},
-		},
+                                items = {
+                                        { name = 'bandage', price = 50, amount = 50 },
+                                }
+                        },
+                },
 		garage = {
 			['ems_garage_1'] = {
 				pedPos = vector4(-407.12, -939.91, 24.0, 269.11),


### PR DESCRIPTION
## Summary
- Add `amount` field to hospital pharmacy items
- Open shop using `ox_inventory` when resource is running, fallback to server event

## Testing
- `luac -p ars_ambulancejob/config.lua`
- `luac -p ars_ambulancejob/client/job/shops.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac47cab10c832683d7a12863297977