### PR TITLE
Ensure ambulance peds spawn at ground level

### DIFF
--- a/ars_ambulancejob/client/modules/utils.lua
+++ b/ars_ambulancejob/client/modules/utils.lua
@@ -1,4 +1,5 @@
 local CreatePed = CreatePed
+local PlaceObjectOnGroundProperly = PlaceObjectOnGroundProperly
 local SetEntityInvincible = SetEntityInvincible
 local SetModelAsNoLongerNeeded = SetModelAsNoLongerNeeded
 local CreateVehicle = CreateVehicle
@@ -48,6 +49,7 @@ function utils.createPed(name, ...)
     if not model then return end
 
     local ped = CreatePed(0, model, ...)
+    PlaceObjectOnGroundProperly(ped)
 
     SetEntityInvincible(ped, true)
     SetModelAsNoLongerNeeded(model)

--- a/ars_ambulancejob/config.lua
+++ b/ars_ambulancejob/config.lua
@@ -64,7 +64,7 @@ Config.Hospitals = {
 	["phillbox"] = {
 		paramedic = {
 			model = "s_m_m_scientist_01",
-			pos = vector4(-468.89, -990.85, 23.69, 97.23),
+                        pos = vector4(-468.89, -990.85, 22.69, 97.23),
 		},
 		bossmenu = {
 			pos = vector3(-488.79, -980.41, 34.3),
@@ -147,7 +147,7 @@ Config.Hospitals = {
 		},
 		garage = {
 			['ems_garage_1'] = {
-				pedPos = vector4(-407.12, -939.91, 24.0, 269.11),
+                                pedPos = vector4(-407.12, -939.91, 23.0, 269.11),
 				model = 'mp_m_weapexp_01',
 				spawn = vector4(-401.78, -937.12, 23.84, 179.89),
 				deposit = vector3(-401.78, -937.12, 23.84),
@@ -165,7 +165,7 @@ Config.Hospitals = {
 		},
 		clothes = {
 			enable = true,
-			pos = vector4(-458.2, -1002.17, 23.75, 90.22),
+                        pos = vector4(-458.2, -1002.17, 22.75, 90.22),
 			model = 'a_f_m_bevhills_01',
 			male = {
 				[1] = {


### PR DESCRIPTION
## Summary
- anchor created peds to the ground using `PlaceObjectOnGroundProperly`
- lower paramedic, garage, and clothing ped z-coordinates to prevent floating

## Testing
- `luac -p ars_ambulancejob/client/modules/utils.lua`
- `luac -p ars_ambulancejob/config.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac47e372c88326b593cdbf449937cf