### PR TITLE
Register ambulance pharmacy shops via ox_inventory

### DIFF
--- a/ars_ambulancejob/client/job/shops.lua
+++ b/ars_ambulancejob/client/job/shops.lua
@@ -34,7 +34,7 @@ local function createShops()
 
                         if self.currentDistance < 1 and IsControlJustReleased(0, 38) then
                             if GetResourceState('ox_inventory') == 'started' then
-                                exports.ox_inventory:openInventory('shop', { id = name, items = pharmacy.items })
+                                exports.ox_inventory:openInventory('shop', { type = name })
                             else
                                 TriggerServerEvent('inventory:server:OpenInventory', 'shop', name, pharmacy.items)
                                 TriggerEvent('inventory:client:SetCurrentStash', name)

--- a/ars_ambulancejob/fxmanifest.lua
+++ b/ars_ambulancejob/fxmanifest.lua
@@ -45,12 +45,13 @@ client_scripts {
 }
 
 server_scripts {
-	"@oxmysql/lib/MySQL.lua",
-	"server/bridge/esx.lua",
-	"server/bridge/qb.lua",
-	"server/main.lua",
-	"server/commands.lua",
-	"server/txadmin.lua",
+        "@oxmysql/lib/MySQL.lua",
+        "server/bridge/esx.lua",
+        "server/bridge/qb.lua",
+        "server/main.lua",
+        "server/shops.lua",
+        "server/commands.lua",
+        "server/txadmin.lua",
 }
 
 files {

--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -1,0 +1,14 @@
+if GetResourceState('ox_inventory') == 'started' then
+    for _, hospital in pairs(Config.Hospitals) do
+        if hospital.pharmacy then
+            for name, pharmacy in pairs(hospital.pharmacy) do
+                exports.ox_inventory:RegisterShop(name, {
+                    name = pharmacy.label,
+                    groups = pharmacy.job and Config.EmsJobs or nil,
+                    inventory = pharmacy.items,
+                })
+            end
+        end
+    end
+end
+


### PR DESCRIPTION
## Summary
- Register each hospital pharmacy server-side using ox_inventory
- Open shops by type client-side
- Include server pharmacy shop registration in fxmanifest

## Testing
- `luacheck ars_ambulancejob/server/shops.lua ars_ambulancejob/client/job/shops.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac5919732483269efdf484204f6d9f