### PR TITLE
Add server-side money handling for ambulance job

### DIFF
--- a/ars_ambulancejob_ox/client/modules/utils.lua
+++ b/ars_ambulancejob_ox/client/modules/utils.lua
@@ -104,6 +104,11 @@ function utils.getClosestHospital()
 end
 
 function utils.addRemoveItem(type, item, quantity)
+    if item == 'money' then
+        TriggerServerEvent('ars_ambulancejob:addRemoveMoney', type ~= 'remove', quantity)
+        return
+    end
+
     local data = {}
     data.toggle = type == "remove"
     data.item = item

--- a/ars_ambulancejob_ox/server/main.lua
+++ b/ars_ambulancejob_ox/server/main.lua
@@ -1,6 +1,8 @@
 player = {}
 distressCalls = {}
 
+local ESX = GetResourceState('es_extended'):find('start') and exports['es_extended']:getSharedObject() or nil
+
 RegisterNetEvent("ars_ambulancejob:updateDeathStatus", function(death)
     local data = {}
     data.target = source
@@ -82,6 +84,26 @@ RegisterNetEvent("ars_ambulancejob:removAddItem", function(data)
         exports.ox_inventory:RemoveItem(source, data.item, data.quantity)
     else
         exports.ox_inventory:AddItem(source, data.item, data.quantity)
+    end
+end)
+
+RegisterNetEvent('ars_ambulancejob:addRemoveMoney', function(add, amount)
+    if QBCore then
+        local Player = QBCore.Functions.GetPlayer(source)
+        if not Player then return end
+
+        if add then
+            Player.Functions.AddMoney('cash', amount)
+        else
+            Player.Functions.RemoveMoney('cash', amount)
+        end
+    elseif ESX then
+        local xPlayer = ESX.GetPlayerFromId(source)
+        if add then
+            xPlayer.addMoney(amount)
+        else
+            xPlayer.removeMoney(amount)
+        end
     end
 end)
 


### PR DESCRIPTION
## Summary
- Route money changes through a new `ars_ambulancejob:addRemoveMoney` event
- Implement server-side money handling using framework APIs

## Testing
- `luac -p ars_ambulancejob_ox/client/modules/utils.lua`
- `luac -p ars_ambulancejob_ox/server/main.lua` *(fails: unexpected symbol near '?')*

------
https://chatgpt.com/codex/tasks/task_e_68ac6544a27c8326a09f2cdf1d317918