### PR TITLE
Ensure spawned NPCs are grounded

### DIFF
--- a/ars_ambulancejob_ox/client/modules/utils.lua
+++ b/ars_ambulancejob_ox/client/modules/utils.lua
@@ -16,6 +16,7 @@ local EndTextCommandSetBlipName = EndTextCommandSetBlipName
 local GetEntityCoords = GetEntityCoords
 local PlayerPedId = PlayerPedId
 local TriggerServerEvent = TriggerServerEvent
+local PlaceObjectOnGroundProperly = PlaceObjectOnGroundProperly
 
 utils = {}
 peds = {}
@@ -47,6 +48,8 @@ function utils.createPed(name, ...)
     if not model then return end
 
     local ped = CreatePed(0, model, ...)
+
+    PlaceObjectOnGroundProperly(ped)
 
     SetEntityInvincible(ped, true)
     SetModelAsNoLongerNeeded(model)


### PR DESCRIPTION
## Summary
- import `PlaceObjectOnGroundProperly` in utils
- ground new peds after creation so they don't float

## Testing
- `luac -p ars_ambulancejob_ox/client/modules/utils.lua`
- `lua /tmp/test_utils.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac655191e4832697b9d1108fb0a5fc