### PR TITLE
Delay shop registration until ox_inventory starts

### DIFF
--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -1,4 +1,4 @@
-if GetResourceState('ox_inventory') == 'started' then
+local function registerPharmacies()
     for _, hospital in pairs(Config.Hospitals) do
         if hospital.pharmacy then
             for name, pharmacy in pairs(hospital.pharmacy) do
@@ -18,5 +18,15 @@ if GetResourceState('ox_inventory') == 'started' then
             end
         end
     end
+end
+
+if GetResourceState('ox_inventory') == 'started' then
+    registerPharmacies()
+else
+    AddEventHandler('onResourceStart', function(resource)
+        if resource == 'ox_inventory' then
+            registerPharmacies()
+        end
+    end)
 end
 


### PR DESCRIPTION
## Summary
- Wait for ox_inventory resource start before registering ambulance pharmacies

## Testing
- `luacheck ars_ambulancejob/server/shops.lua`

------
https://chatgpt.com/codex/tasks/task_e_68ac7377dbb4832698764347f2daa184