### PR TITLE
Use count for pharmacy shop items

### DIFF
--- a/ars_ambulancejob/config.lua
+++ b/ars_ambulancejob/config.lua
@@ -117,14 +117,14 @@ Config.Hospitals = {
 					color = 2,
 					pos = vector3(-462.8, -1014.48, 23.72),
 				},
-				items = {
-                                        { name = 'medicalbag',    price = 50, amount = 50 },
-                                        { name = 'bandage',       price = 50, amount = 50 },
-                                        { name = 'defibrillator', price = 50, amount = 50 },
-                                        { name = 'tweezers',      price = 50, amount = 50 },
-                                        { name = 'burncream',     price = 50, amount = 50 },
-                                        { name = 'suturekit',     price = 50, amount = 50 },
-                                        { name = 'icepack',       price = 50, amount = 50 },
+                                items = {
+                                        { name = 'medicalbag',    price = 50, count = 50 },
+                                        { name = 'bandage',       price = 50, count = 50 },
+                                        { name = 'defibrillator', price = 50, count = 50 },
+                                        { name = 'tweezers',      price = 50, count = 50 },
+                                        { name = 'burncream',     price = 50, count = 50 },
+                                        { name = 'suturekit',     price = 50, count = 50 },
+                                        { name = 'icepack',       price = 50, count = 50 },
                                 }
                         },
 			["ems_shop_2"] = {
@@ -141,7 +141,7 @@ Config.Hospitals = {
 					pos = vector3(-447.13, -1033.49, 23.8),
 				},
                                 items = {
-                                        { name = 'bandage', price = 50, amount = 50 },
+                                        { name = 'bandage', price = 50, count = 50 },
                                 }
                         },
                 },

--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -453,7 +453,7 @@ local function qbProductsToOx(products)
                 name     = string.lower(p.name),
                 price    = tonumber(p.price) or 0,
                 metadata = p.info,
-                count    = p.amount
+                count    = p.count or p.amount
             }
         end
     end


### PR DESCRIPTION
## Summary
- refactor ambulance job pharmacy items to use `count`
- map `qbProductsToOx` to read item `count`

## Testing
- `luacheck ars_ambulancejob/config.lua`
- `luacheck ox_inventory/modules/bridge/qb/server.lua` *(fails: expected 'then' near '?')*


------
https://chatgpt.com/codex/tasks/task_e_68ac73ac8f0c83269bc148188d768ca1