### PR TITLE
Remove EMS references in ambulance job

### DIFF
--- a/ars_ambulancejob/!INSTALLATION/items.lua
+++ b/ars_ambulancejob/!INSTALLATION/items.lua
@@ -54,8 +54,8 @@
     description = "An ice pack used to reduce swelling and provide relief from pain and inflammation.",
 },
 
-['emstablet'] = {
-    label = 'Ems tablet',
+['ambulancetablet'] = {
+    label = 'Ambulance tablet',
     weight = 200,
     stack = true,
     client = {

--- a/ars_ambulancejob/client/job/clothing.lua
+++ b/ars_ambulancejob/client/job/clothing.lua
@@ -6,7 +6,7 @@ local SetBlockingOfNonTemporaryEvents = SetBlockingOfNonTemporaryEvents
 
 local function openClothingMenu(clothes)
     lib.registerContext({
-        id = 'ems_clothing_menu',
+        id = 'ambulance_clothing_menu',
         title = 'Clothing Menu',
         options = {
             {
@@ -60,7 +60,7 @@ local function openClothingMenu(clothes)
         }
     })
 
-    lib.showContext('ems_clothing_menu')
+    lib.showContext('ambulance_clothing_menu')
 end
 
 function initClothes(data, jobs)

--- a/ars_ambulancejob/client/job/garage.lua
+++ b/ars_ambulancejob/client/job/garage.lua
@@ -79,10 +79,10 @@ local function depositVehicle(data)
                 lib.hideTextUI()
 
                 if Config.UsePedToDepositVehicle then
-                    local emsDriver = utils.createPed(data.model, data.driverSpawnCoords)
-                    FreezeEntityPosition(emsDriver, false)
+                    local ambulanceDriver = utils.createPed(data.model, data.driverSpawnCoords)
+                    FreezeEntityPosition(ambulanceDriver, false)
 
-                    TaskEnterVehicle(emsDriver, vehicleToDelete, -1, -1, 1.0, 1, 0)
+                    TaskEnterVehicle(ambulanceDriver, vehicleToDelete, -1, -1, 1.0, 1, 0)
 
                     Wait(1000)
 
@@ -90,17 +90,17 @@ local function depositVehicle(data)
                     while GetPedInVehicleSeat(vehicleToDelete, 1) ~= 0 do Wait(1) end
                     while GetPedInVehicleSeat(vehicleToDelete, 2) ~= 0 do Wait(1) end
 
-                    TaskVehicleDriveWander(emsDriver, vehicleToDelete, 60.0, 8)
+                    TaskVehicleDriveWander(ambulanceDriver, vehicleToDelete, 60.0, 8)
 
                     Wait(20 * 1000) -- 20 seconds
 
                     NetworkFadeOutEntity(vehicleToDelete, false, true)
-                    NetworkFadeOutEntity(emsDriver, false, true)
+                    NetworkFadeOutEntity(ambulanceDriver, false, true)
 
                     Wait(1 * 1000)
 
-                    DeletePed(emsDriver)
-                    emsDriver = nil
+                    DeletePed(ambulanceDriver)
+                    ambulanceDriver = nil
                 end
 
                 DeleteVehicle(vehicleToDelete)

--- a/ars_ambulancejob/client/stretcher.lua
+++ b/ars_ambulancejob/client/stretcher.lua
@@ -29,11 +29,11 @@ local usingStretcher = false
 local currentStretcher = nil
 local patientOnStretcher = nil
 
-local function isEmsVehicle(vehicle)
+local function isAmbulanceVehicle(vehicle)
     local vehicleModel = GetEntityModel(vehicle)
     local vehicleClass = GetVehicleClass(vehicle)
 
-    for index, model in pairs(Config.EmsVehicles) do
+    for index, model in pairs(Config.AmbulanceVehicles) do
         if joaat(model) == vehicleModel or GetVehicleClassFromName(model) == vehicleClass then return true end
     end
 
@@ -161,7 +161,7 @@ local function vehicleInteractions()
             label = locale('take_stretcher'),
             groups = Config.EmsJobs,
             cn = function(entity, distance, coords, name)
-                return isEmsVehicle(entity) and not usingStretcher
+                return isAmbulanceVehicle(entity) and not usingStretcher
             end,
             fn = function(data)
                 local vehicle = type(data) == "number" and data or data.entity
@@ -179,7 +179,7 @@ local function vehicleInteractions()
             label = locale('put_stretcher'),
             groups = Config.EmsJobs,
             cn = function(entity, distance, coords, name)
-                return isEmsVehicle(entity) and usingStretcher and not patientOnStretcher
+                return isAmbulanceVehicle(entity) and usingStretcher and not patientOnStretcher
             end,
             fn = function(data)
                 local vehicle = type(data) == "number" and data or data.entity
@@ -196,7 +196,7 @@ local function vehicleInteractions()
             label = locale('put_patient_in_vehicle'),
             groups = Config.EmsJobs,
             cn = function(entity, distance, coords, name)
-                return isEmsVehicle(entity) and usingStretcher and patientOnStretcher
+                return isAmbulanceVehicle(entity) and usingStretcher and patientOnStretcher
             end,
             fn = function(data)
                 local dataToSend = {}
@@ -214,7 +214,7 @@ local function vehicleInteractions()
             label = locale('take_patient_from_vehicle'),
             groups = Config.EmsJobs,
             cn = function(entity, distance, coords, name)
-                return isEmsVehicle(entity) and Entity(entity).state?.patient
+                return isAmbulanceVehicle(entity) and Entity(entity).state?.patient
             end,
             fn = function(data)
                 local dataToSend = {}

--- a/ars_ambulancejob/config.lua
+++ b/ars_ambulancejob/config.lua
@@ -5,7 +5,7 @@ Config                         = {}
 Config.Debug                   = false
 
 Config.ClothingScript          = 'illenium-appearance' -- 'illenium-appearance', 'fivem-appearance' ,'core' or false -- to disable
-Config.EmsJobs                 = { "ambulance", "ems" }
+Config.EmsJobs                 = { "ambulance" }
 Config.RespawnTime             = 0                     -- in minutes
 Config.UseInterDistressSystem  = true
 Config.WaitTimeForNewCall      = 5                     -- minutes
@@ -39,7 +39,7 @@ Config.NpcReviveCommand        = "ambulance" -- this will work only when there a
 Config.UsePedToDepositVehicle  = false       -- if false the vehicle will instantly despawns
 Config.ExtraEffects            = true        -- false >> disables the screen shake and the black and white screen
 
-Config.EmsVehicles             = {           -- vehicles that have access to the props (cones and ecc..)
+Config.AmbulanceVehicles       = {           -- vehicles that have access to the props (cones and ecc..)
 	'ambulance',
 	'ambulance2',
 }
@@ -94,17 +94,17 @@ Config.Hospitals = {
 
 		},
 		stash = {
-			['ems_stash_1'] = {
+                    ['ambulance_stash_1'] = {
 				slots = 50,
 				weight = 100, -- kg
 				min_grade = 0,
-				label = 'Ems stash',
+                                label = 'Ambulance stash',
 				shared = true, -- false if you want to make everyone has a personal stash
 				pos = vector3(-459.97, -994.69, 23.74)
 			}
 		},
 		pharmacy = {
-			["ems_shop_1"] = {
+                    ["ambulance_shop_1"] = {
 				job = true,
 				label = "Pharmacy",
 				grade = 0, -- works only if job true
@@ -127,7 +127,7 @@ Config.Hospitals = {
                                         { name = 'icepack',       price = 50, amount = 50 },
                                 }
                         },
-			["ems_shop_2"] = {
+                    ["ambulance_shop_2"] = {
 				job = false,
 				label = "Pharmacy",
 				grade = 0, -- works only if job true
@@ -146,7 +146,7 @@ Config.Hospitals = {
                         },
                 },
 		garage = {
-			['ems_garage_1'] = {
+                    ['ambulance_garage_1'] = {
                                 pedPos = vector4(-407.12, -939.91, 23.0, 269.11),
 				model = 'mp_m_weapexp_01',
 				spawn = vector4(-401.78, -937.12, 23.84, 179.89),


### PR DESCRIPTION
## Summary
- restrict ambulance job config to only `"ambulance"`
- remove remaining EMS-specific labels and identifiers
- update internal logic to use `AmbulanceVehicles`

## Testing
- `luacheck ars_ambulancejob/config.lua ars_ambulancejob/client/stretcher.lua ars_ambulancejob/client/job/clothing.lua ars_ambulancejob/client/job/garage.lua 'ars_ambulancejob/!INSTALLATION/items.lua'` *(fails: undefined globals and invalid installation snippet)*

------
https://chatgpt.com/codex/tasks/task_e_68ac73946194832693bd93b1a1257a05