### PR TITLE
fix: rewrite pharmacy shop registration

### DIFF
--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -1,10 +1,9 @@
-codex/replace-openinventory-with-custom-event
 local QBCore = GetResourceState('qb-core'):find('start') and exports['qb-core']:GetCoreObject() or nil
 local ESX = GetResourceState('es_extended'):find('start') and exports['es_extended']:getSharedObject() or nil
 
-if GetResourceState('ox_inventory') == 'started' then
 local function registerPharmacies()
- main
+    if GetResourceState('ox_inventory') ~= 'started' then return end
+
     for _, hospital in pairs(Config.Hospitals) do
         if hospital.pharmacy then
             for name, pharmacy in pairs(hospital.pharmacy) do
@@ -25,7 +24,7 @@ local function registerPharmacies()
         end
     end
 end
- codex/replace-openinventory-with-custom-event
+
 RegisterNetEvent('ars_ambulancejob:openPharmacy', function(name)
     local src = source
     local pharmacy
@@ -59,14 +58,14 @@ RegisterNetEvent('ars_ambulancejob:openPharmacy', function(name)
         TriggerEvent('inventory:server:OpenInventory', 'shop', name, pharmacy.items)
     end
 end)
+
 if GetResourceState('ox_inventory') == 'started' then
     registerPharmacies()
-else
-    AddEventHandler('onResourceStart', function(resource)
-        if resource == 'ox_inventory' then
-            registerPharmacies()
-        end
-    end)
 end
- main
+
+AddEventHandler('onResourceStart', function(resource)
+    if resource == 'ox_inventory' then
+        registerPharmacies()
+    end
+end)
 


### PR DESCRIPTION
## Summary
- remove leftover codex markers in ambulance shop script
- rewrite pharmacy registration and open event in standard Lua
- ensure shops register when `ox_inventory` starts

## Testing
- `luac -p ars_ambulancejob/server/shops.lua` *(fails: command not found)*
- `apt-get install -y lua5.4` *(fails: Unable to locate package lua5.4)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8afb21bc83269c065fcf8e8de635