### PR TITLE
Use ox_inventory openInventory for pharmacies

### DIFF
--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -94,7 +94,7 @@ RegisterNetEvent('ars_ambulancejob:openPharmacy', function(name)
     end
 
     if GetResourceState('ox_inventory') == 'started' then
-        TriggerClientEvent('qb-inventory:client:OpenShop', src, name) -- puente de ox_inventory
+        exports.ox_inventory:openInventory(src, 'shop', name)
     else
         exports['qb-inventory']:OpenShop(src, name)
     end


### PR DESCRIPTION
## Summary
- use `ox_inventory:openInventory` instead of triggering qb-inventory shop client event when opening pharmacy shops

## Testing
- `luac -p ars_ambulancejob/server/shops.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ac9fca49a08326b119443e06e1d25c