### PR TITLE
Wrap pharmacy registration in resource start handler

### DIFF
--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -100,17 +100,10 @@ RegisterNetEvent('ars_ambulancejob:openPharmacy', function(name)
     end
 end)
 
-if GetResourceState('ox_inventory') == 'started' or GetResourceState('qb-inventory') == 'started' then
-    registerPharmacies()
-end
-
-
-
--- main
-
-
 AddEventHandler('onResourceStart', function(resource)
-    if resource == 'ox_inventory' or resource == 'qb-inventory' then
+    if resource ~= GetCurrentResourceName() then return end
+
+    if GetResourceState('ox_inventory') == 'started' or GetResourceState('qb-inventory') == 'started' then
         registerPharmacies()
     end
 end)


### PR DESCRIPTION
## Summary
- register pharmacies when ars_ambulancejob starts and required inventories are running

## Testing
- `luacheck ars_ambulancejob/server/shops.lua`
- `bash start.sh` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68aca0b73e0c8326a7ba3cb61c86a41e