### PR TITLE
refactor: remove unsupported ped model export

### DIFF
--- a/ars_ambulancejob/client/bridge/esx.lua
+++ b/ars_ambulancejob/client/bridge/esx.lua
@@ -27,11 +27,11 @@ function toggleClothes(toggle, clothes)
         utils.debug("Job Grade " .. jobGrade)
 
         if Config.ClothingScript and Config.ClothingScript ~= 'core' then
-            local model = exports[Config.ClothingScript]:getPedModel(playerPed)
+            local model = GetEntityModel(playerPed)
 
-            if model == 'mp_m_freemode_01' then
+            if model == GetHashKey('mp_m_freemode_01') then
                 data = clothes.male[jobGrade] or clothes.male[1]
-            elseif model == 'mp_f_freemode_01' then
+            elseif model == GetHashKey('mp_f_freemode_01') then
                 data = clothes.female[jobGrade] or clothes.female[1]
             end
 

--- a/ars_ambulancejob/client/bridge/qb.lua
+++ b/ars_ambulancejob/client/bridge/qb.lua
@@ -25,11 +25,11 @@ function toggleClothes(toggle, clothes)
         utils.debug("Job Grade " .. jobGrade)
 
         if Config.ClothingScript and Config.ClothingScript ~= 'core' then
-            local model = exports[Config.ClothingScript]:getPedModel(playerPed)
+            local model = GetEntityModel(playerPed)
 
-            if model == 'mp_m_freemode_01' then
+            if model == GetHashKey('mp_m_freemode_01') then
                 data = clothes.male[jobGrade] or clothes.male[1]
-            elseif model == 'mp_f_freemode_01' then
+            elseif model == GetHashKey('mp_f_freemode_01') then
                 data = clothes.female[jobGrade] or clothes.female[1]
             end
 


### PR DESCRIPTION
## Summary
- use GetEntityModel and hash comparison to determine ped gender instead of unsupported `getPedModel`

## Testing
- `luacheck ars_ambulancejob/client/bridge/qb.lua ars_ambulancejob/client/bridge/esx.lua`


------
https://chatgpt.com/codex/tasks/task_e_68acbd67f3448326b8802e9088482390