### PR TITLE
Use server-side inventory API for ambulance pharmacy

### DIFF
--- a/ars_ambulancejob/server/shops.lua
+++ b/ars_ambulancejob/server/shops.lua
@@ -94,7 +94,11 @@ RegisterNetEvent('ars_ambulancejob:openPharmacy', function(name)
     end
 
     if GetResourceState('ox_inventory') == 'started' then
-        exports.ox_inventory:openInventory(src, 'shop', name)
+        if exports.ox_inventory.forceOpenInventory then
+            exports.ox_inventory:forceOpenInventory(src, 'shop', { id = name })
+        else
+            TriggerClientEvent('ox_inventory:openInventory', src, 'shop', { id = name })
+        end
     else
         exports['qb-inventory']:OpenShop(src, name)
     end


### PR DESCRIPTION
## Summary
- Ensure pharmacy uses server-side inventory events

## Testing
- `luac -p ars_ambulancejob/server/shops.lua`
- `lua - <<'EOF' ...` (ox_inventory)
- `lua - <<'EOF' ...` (qb-inventory)


------
https://chatgpt.com/codex/tasks/task_e_68acbd86f6788326a6cd1b4774dcdfe1