### PR TITLE
refactor: consolidate player action config

### DIFF
--- a/qb-jobcreator/client/actions.lua
+++ b/qb-jobcreator/client/actions.lua
@@ -32,8 +32,21 @@ A.clean     = function() TriggerEvent('qb-mechanicjob:client:CleanVehicle') end
 A.impound   = function() TriggerEvent('police:client:ImpoundVehicle') end
 
 RegisterNetEvent('qb-jobcreator:client:doAction', function(action)
-  local fn = A[action]
-  if fn then fn() else QBCore.Functions.Notify('Acción no disponible: '..tostring(action), 'error') end
+  local pd = QBCore.Functions.GetPlayerData() or {}
+  local jobName = (pd.job and pd.job.name) or ''
+  local byJob = (Config.PlayerActionsByJob or {})[jobName] or {}
+  local allowed = false
+  for _, v in ipairs(byJob) do if v == action then allowed = true break end end
+  if allowed and ((Config.PlayerActionsDefaults or {})[action] ~= false) then
+    local fn = A[action]
+    if fn then
+      fn()
+    else
+      QBCore.Functions.Notify('Acción no disponible: '..tostring(action), 'error')
+    end
+  else
+    QBCore.Functions.Notify('Acción no disponible: '..tostring(action), 'error')
+  end
 end)
 
 -- Helpers

--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -64,7 +64,7 @@ Config.DefaultGrades = Config.DefaultGrades or {
 }
 
 -- Acciones habilitables
-Config.PlayerActions = Config.PlayerActions or {
+Config.PlayerActionsDefaults = Config.PlayerActionsDefaults or {
   search   = true,
   handcuff = true,
   drag     = true,
@@ -100,7 +100,7 @@ Config.Garages = {
   SpawnEvent    = nil,         -- si tu fork expone un evento de spawn (server)
 }
 
-Config.PlayerActions = Config.PlayerActions or {
+Config.PlayerActionsByJob = Config.PlayerActionsByJob or {
   police    = { 'cuff', 'escort', 'putinveh', 'takeout', 'bill' },
   ambulance = { 'revive', 'heal' },
   mechanic  = { 'repair', 'clean', 'impound' },

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -208,13 +208,18 @@ end)
 -- ===== CRUD de trabajos =====
 RegisterNetEvent('qb-jobcreator:server:createJob', function(data)
   local src = source; if not ensurePerm(src) then return end
+  local name = string.lower((data.name or ''):gsub('%s+',''))
   local job = {
-    name = string.lower((data.name or ''):gsub('%s+','')),
+    name = name,
     label = data.label or 'Trabajo',
     type = data.type or 'generic',
     whitelisted = data.whitelisted or false,
     grades = next(data.grades or {}) and data.grades or Config.DefaultGrades,
-    actions = { player = Config.PlayerActions, vehicle = Config.VehicleActions }
+    actions = {
+      defaults = Config.PlayerActionsDefaults,
+      player   = Config.PlayerActionsByJob[name] or {},
+      vehicle  = Config.VehicleActions
+    }
   }
   if job.name == '' then return end
   Runtime.Jobs[job.name] = job


### PR DESCRIPTION
## Summary
- separate global and per-job player action config
- copy defaults and job lists when creating jobs
- validate actions against config on client

## Testing
- `luac -p qb-jobcreator/config.lua qb-jobcreator/server/main.lua qb-jobcreator/client/actions.lua`


------
https://chatgpt.com/codex/tasks/task_e_68acd667d7fc83269cbe5dd13d8429b1