### PR TITLE
fix: unify recruit NUI callback

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -81,8 +81,10 @@ end)
 RegisterNUICallback('recruit', function(data, cb)
   local jobName = data and data.job
   local grade = tonumber(data and data.grade) or 0
-  local targetId = tonumber(data and data.target) or -1
-  if jobName and targetId ~= -1 then TriggerServerEvent('qb-jobcreator:server:recruit', jobName, grade, targetId) end
+  local targetId = tonumber(data and (data.target or data.sid or data.targetId)) or -1
+  if jobName and targetId ~= -1 then
+    TriggerServerEvent('qb-jobcreator:server:recruit', jobName, grade, targetId)
+  end
   cb({ ok = true })
 end)
 
@@ -103,12 +105,6 @@ RegisterNUICallback('nearbyPlayers', function(data, cb)
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getNearbyPlayers', function(list)
     cb(list or {})
   end, data.job, data.radius or 3.5)
-end)
-
--- Reclutar a un ID concreto (por si la UI lo usa)
-RegisterNUICallback('recruit', function(data, cb)
-  TriggerServerEvent('qb-jobcreator:server:recruit', data.job, tonumber(data.grade) or 0, tonumber(data.targetId) or -1)
-  cb({ ok = true })
 end)
 
 -- Guardar data de una zona (para “vehículos por rango”)

--- a/qb-jobcreator/client/nui.lua
+++ b/qb-jobcreator/client/nui.lua
@@ -52,11 +52,6 @@ RegisterNUICallback('getCoords', function(_, cb)
   cb({ x = c.x + 0.0, y = c.y + 0.0, z = c.z + 0.0, w = GetEntityHeading(ped) + 0.0 })
 end)
 
-RegisterNUICallback('recruit', function(data, cb)
-  TriggerServerEvent('qb-jobcreator:server:recruit', data.job, data.grade, data.sid)
-  cb('ok')
-end)
-
 RegisterNUICallback('fire', function(data, cb)
   TriggerServerEvent('qb-jobcreator:server:fire', data.job, data.citizenid); cb('ok')
 end)


### PR DESCRIPTION
## Summary
- ensure recruit NUI callback handles sid, target, or targetId and remove duplicate
- drop redundant recruit handler from legacy NUI script

## Testing
- `luac -p qb-jobcreator/client/main.lua`
- `luac -p qb-jobcreator/client/nui.lua`


------
https://chatgpt.com/codex/tasks/task_e_68acd6739ff88326bead0448a65d87f0