### PR TITLE
Implement crafting recipes and menu

### DIFF
--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -89,7 +89,27 @@ Config.ZoneTypes = Config.ZoneTypes or {
 }
 
 Config.CraftingRecipes = Config.CraftingRecipes or {
-  bandage = { needs = { {item='cloth', qty=2} }, time = 3000 },
+  bandage = {
+    label = 'Vendaje',
+    jobs = { 'ambulance' },
+    needs = {
+      { item = 'cloth',   qty = 2 },
+      { item = 'alcohol', qty = 1 },
+    },
+    amount = 1,
+    time = 3000
+  },
+
+  repairkit = {
+    label = 'Kit de reparación',
+    jobs = { 'mechanic' },
+    needs = {
+      { item = 'metalscrap', qty = 10 },
+      { item = 'plastic',    qty = 4 },
+    },
+    amount = 1,
+    time = 5000
+  }
 }
 
 -- Integración de garajes


### PR DESCRIPTION
## Summary
- define Config.CraftingRecipes with bandage and repairkit examples
- add client qb-menu to display available crafting recipes
- implement server event to consume ingredients and produce crafted items

## Testing
- `luac -p qb-jobcreator/config.lua`
- `luac -p qb-jobcreator/client/zones.lua`
- `luac -p qb-jobcreator/server/main.lua`
- ⚠️ `luacheck qb-jobcreator` *(failed: LuaRocks manifest download error)*

------
https://chatgpt.com/codex/tasks/task_e_68acd72f3b208326a5f9f94af9597985