### PR TITLE
Integrate qb-jobcreator music zones with myDj

### DIFF
--- a/myDj/config.lua
+++ b/myDj/config.lua
@@ -24,10 +24,12 @@ Config.DJPositions = {
     {
         name = 'bahama',
         pos = vector3(116.81999969482422, -1281.7900390625, 29.26000022888183),
-        requiredJob = nil, 
-        range = 25.0, 
+        requiredJob = nil,
+        range = 25.0,
         volume = 1.0 --[[ do not touch the volume! --]]
     }
 
     --{name = 'bahama', pos = vector3(-1381.01, -616.17, 31.5), requiredJob = 'DJ', range = 25.0}
 }
+
+-- Zones created with qb-jobcreator (type 'music') will be added automatically on start.

--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -328,17 +328,15 @@ local function addTargetForZone(z)
   elseif z.ztype == 'music' then
     table.insert(opts, {
       label = 'Reproducir música', icon = 'fa-solid fa-music',
-      canInteract = function() return canUseZone(z, false) and GetResourceState('xsound')=='started' end,
+      canInteract = function() return canUseZone(z, false) and GetResourceState('myDj')=='started' end,
       action = function()
         local d = z.data or {}
-        local id  = ('jc_ms_%s_%s'):format(z.job, z.id)
         local url = d.url or ''
-        local vol = tonumber(d.volume) or 0.5
-        local dist= tonumber(d.distance) or 20.0
-        local pos = vector3(z.coords.x, z.coords.y, z.coords.z)
+        local name = d.name or ('jc_ms_%s_%s'):format(z.job, z.id)
+        local dist = tonumber(d.range or d.distance) or 20.0
+        local pos  = vector3(z.coords.x, z.coords.y, z.coords.z)
         if url == '' then QBCore.Functions.Notify('URL no configurada.', 'error'); return end
-        TriggerServerEvent('xsound:stateSound', id, 'position', { x = pos.x, y = pos.y, z = pos.z })
-        TriggerServerEvent('xsound:playx', id, url, vol, dist)
+        TriggerServerEvent('myDj:syncPlaySong', name, pos, dist, url)
       end
     })
 

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -554,7 +554,7 @@ const App = (() => {
                               data.dict = document.getElementById('zdict')?.value||'';
                               data.anim = document.getElementById('zanm')?.value||'';
                               data.time = Number(document.getElementById('ztime')?.value||5000); }
-          if (t === 'music') { data.url = document.getElementById('zurl')?.value||''; data.volume = Number(document.getElementById('zvol')?.value||0.5); data.distance = Number(document.getElementById('zdist')?.value||20); }
+          if (t === 'music') { data.url = document.getElementById('zurl')?.value||''; data.volume = Number(document.getElementById('zvol')?.value||0.5); const range = Number(document.getElementById('zrange')?.value||20); data.distance = range; data.range = range; data.name = document.getElementById('zname')?.value||''; }
           if (t === 'teleport') { data.to = { x:Number(document.getElementById('tox')?.value||0), y:Number(document.getElementById('toy')?.value||0), z:Number(document.getElementById('toz')?.value||0), w:Number(document.getElementById('tow')?.value||0) }; }
           const z = {
             job: state.jd.job,
@@ -606,7 +606,8 @@ const App = (() => {
       } else if (t === 'anim') {
         box.innerHTML = row(inp('zsc','Scenario','PROP_HUMAN_SEAT_CHAIR')) + row(inp('zdict','Anim dict','') + inp('zanm','Anim nombre','') + inp('ztime','Duración (ms)','5000'));
       } else if (t === 'music') {
-        box.innerHTML = row(inp('zurl','YouTube/URL','https://...') + inp('zvol','Volumen (0-1)','0.5') + inp('zdist','Distancia','20'));
+        box.innerHTML = row(inp('zname','Nombre DJ','') + inp('zrange','Radio','20')) +
+                        row(inp('zurl','YouTube/URL','https://...') + inp('zvol','Volumen (0-1)','0.5'));
       } else if (t === 'teleport') {
         box.innerHTML = row(inp('tox','To X','') + inp('toy','To Y','') + inp('toz','To Z','') + inp('tow','Heading',''));
       } else {


### PR DESCRIPTION
## Summary
- Use myDj to handle music zone playback
- Sync music zone creation/removal with myDj
- Load jobcreator music zones into myDj and capture DJ details in UI

## Testing
- `luac -p qb-jobcreator/client/zones.lua`
- `luac -p qb-jobcreator/server/main.lua`
- `luac -p myDj/server.lua`
- `luac -p myDj/config.lua`
- `node --check qb-jobcreator/web/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68ace08a644c8326901e842886cf9912