### PR TITLE
Integrate ars_ambulancejob events

### DIFF
--- a/qb-jobcreator/client/actions.lua
+++ b/qb-jobcreator/client/actions.lua
@@ -1,22 +1,19 @@
 QBCore = exports['qb-core']:GetCoreObject()
 local function started(r) return GetResourceState(r) == 'started' end
-local function anyStarted(rs)
-  for _, r in ipairs(rs or {}) do if started(r) then return true end end
-end
 
 local A = {}
 
 -- EMS
 A.revive = function()
-  if anyStarted(Config.Integrations.HospitalResources) then
-    TriggerEvent(Config.Integrations.HospitalReviveEvent)
+  if started('ars_ambulancejob') then
+    TriggerServerEvent(Config.Integrations.HospitalReviveEvent, { revive = true })
   else
     QBCore.Functions.Notify('Recurso de hospital/ambulancia no activo.', 'error')
   end
 end
 A.heal = function()
-  if anyStarted(Config.Integrations.HospitalResources) then
-    TriggerEvent(Config.Integrations.HospitalHealEvent)
+  if started('ars_ambulancejob') then
+    TriggerServerEvent(Config.Integrations.HospitalHealEvent, { heal = true })
   else
     QBCore.Functions.Notify('Recurso de hospital no activo.', 'error')
   end

--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -29,10 +29,10 @@ Config.Integrations = Config.Integrations or {
   -- esx_ambulancejob:
   --   Revivir -> 'esx_ambulancejob:revive'
   --   Curar   -> 'esx_ambulancejob:treat'
-  HospitalReviveEvent = 'hospital:client:Revive',
-  HospitalHealEvent   = 'hospital:client:TreatWounds',
+  HospitalReviveEvent = 'ars_ambulancejob:healPlayer',
+  HospitalHealEvent   = 'ars_ambulancejob:healPlayer',
   -- Recursos a verificar antes de disparar los eventos
-  HospitalResources   = { 'qb-ambulancejob', 'hospital' },
+  HospitalResources   = { 'ars_ambulancejob' },
 }
 
 -- ===== Multi‑trabajo =====


### PR DESCRIPTION
## Summary
- route revive and heal actions through ars_ambulancejob
- trigger server-side heal events with explicit revive/heal flags
- ensure ars_ambulancejob is running before attempting EMS actions

## Testing
- `luac -p qb-jobcreator/config.lua qb-jobcreator/client/actions.lua`

------
https://chatgpt.com/codex/tasks/task_e_68ace2d3407483269ad4860563d8a02d