### PR TITLE
Use shop mode for qb-clothing

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -264,7 +264,7 @@ local function addTargetForZone(z)
           -- tienda de ropa / vestuario
           TriggerEvent('illenium-appearance:client:openClothingShop')
         elseif GetResourceState('qb-clothing')=='started' then
-          TriggerEvent('qb-clothing:client:openMenu')
+          TriggerEvent('qb-clothing:client:openMenu', true) -- true = shop mode
         else
           QBCore.Functions.Notify('No hay sistema de vestuario disponible.', 'error')
         end


### PR DESCRIPTION
## Summary
- Open qb-clothing menu in shop mode when resource is active to restrict outfit saving

## Testing
- `luac -p qb-jobcreator/client/zones.lua`


------
https://chatgpt.com/codex/tasks/task_e_68acf671554c832680a4e88dc1921a3c