### PR TITLE
Use ox inventory for job creator shops

### DIFF
--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -20,7 +20,7 @@ Config.Integrations = Config.Integrations or {
   UseQbTarget     = true,
   UseOxTarget     = false,
   UseQbManagement = false,   -- fondos de sociedad; si no, fallback propio en DB
-  UseQbInventory  = true,
+  UseQbInventory  = false,
   UseBossMenu     = true,
   -- Eventos de hospital. Ajusta los nombres según el script que uses
   -- qb-ambulancejob (por defecto):


### PR DESCRIPTION
## Summary
- disable qb inventory integration to use ox_inventory for job creator shops

## Testing
- `lua test_openShop.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ae12487920832688a22aa605e2a16c