### PR TITLE
fix: set resource name on load

### DIFF
--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -55,6 +55,8 @@ const App = (() => {
     ? GetParentResourceName()
     : (window.resourceName || 'qb-jobcreator');
 
+  window.resourceName = RESOURCE;
+
   function post(name, data = {}) {
     return fetch(`https://${RESOURCE}/${name}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- ensure `window.resourceName` is populated with the runtime resource name for NUI requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae140cdc988326b1320ca32da71256