### PR TITLE
feat: integrate myDj menu in job zones

### DIFF
--- a/myDj/client.lua
+++ b/myDj/client.lua
@@ -151,6 +151,21 @@ AddEventHandler('myDj:open', function()
     end)
 end)
 
+RegisterNetEvent('myDj:client:openMenu', function(djName, djPos, djRange)
+    currentDJ = {
+        name = djName or ('dj_'..math.random(1000,9999)),
+        pos = djPos or GetEntityCoords(PlayerPedId()),
+        range = djRange or 20.0,
+        volume = 1.0
+    }
+    SetNuiFocus(true, true)
+    isDjOpen = true
+    SendNUIMessage({type = 'open'})
+    QBCore.Functions.TriggerCallback('myDJ:requestPlaylistsAndSongs', function(playlists, songs)
+        SendNUIMessage({type = 'getPlaylists', playlists = playlists, songs = songs})
+    end)
+end)
+
 -- sync timestamps
 Citizen.CreateThread(function()
     while true do

--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -360,12 +360,10 @@ local function addTargetForZone(z)
       canInteract = function() return canUseZone(z, false) and GetResourceState('myDj')=='started' end,
       action = function()
         local d = z.data or {}
-        local url = d.url or ''
         local name = d.name or ('jc_ms_%s_%s'):format(z.job, z.id)
         local dist = tonumber(d.range or d.distance) or 20.0
         local pos  = vector3(z.coords.x, z.coords.y, z.coords.z)
-        if url == '' then QBCore.Functions.Notify('URL no configurada.', 'error'); return end
-        TriggerServerEvent('myDj:syncPlaySong', name, pos, dist, url)
+        TriggerEvent('myDj:client:openMenu', name, pos, dist)
       end
     })
 


### PR DESCRIPTION
## Summary
- Open myDj menu from job creator music zones instead of forcing a song
- Add myDj client event to initialise DJ context and display NUI

## Testing
- `luacheck qb-jobcreator/client/zones.lua myDj/client.lua` (warnings: 399, errors: 0)


------
https://chatgpt.com/codex/tasks/task_e_68ae15d30e908326941df26025339082