### PR TITLE
feat: add crafting nui

### DIFF
--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -753,3 +753,59 @@ const App = (() => {
 
   return {};
 })();
+
+// ===== Panel de Crafteo =====
+const CraftUI = (() => {
+  let zoneId = null;
+  let visible = false;
+
+  function open(payload) {
+    zoneId = payload.zone;
+    const recipes = payload.recipes || {};
+    const wrap = document.getElementById('craft-list');
+    wrap.innerHTML = '';
+    Object.entries(recipes).forEach(([name, rec]) => {
+      const card = document.createElement('div');
+      card.className = 'craft-item';
+      const out = rec.output && rec.output.item || name;
+      const inputs = (rec.inputs || [])
+        .map(i => `<li>${i.amount || i.qty || 1}x ${i.item}</li>`)
+        .join('');
+      const imgSrc = `nui://qb-inventory/html/images/${out}.png`;
+      card.innerHTML = `
+        <img src="${imgSrc}" alt="${out}">
+        <div class="materials"><strong>${rec.label || out}</strong><ul>${inputs}</ul></div>
+        <button class="btn craft-btn" data-recipe="${name}">Fabricar</button>`;
+      wrap.appendChild(card);
+    });
+    document.getElementById('craft').classList.remove('hidden');
+    visible = true;
+  }
+
+  function close() {
+    document.getElementById('craft').classList.add('hidden');
+    visible = false;
+  }
+
+  window.addEventListener('message', (e) => {
+    const data = e.data || {};
+    if (data.action === 'openCraft') open(data.payload || {});
+    if (data.action === 'hide') close();
+  });
+
+  document.addEventListener('click', (e) => {
+    if (e.target.classList.contains('craft-btn')) {
+      const recipe = e.target.dataset.recipe;
+      post('craft', { zone: zoneId, recipe });
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && visible) {
+      post('close');
+      close();
+    }
+  });
+
+  return { open, close };
+})();

--- a/qb-jobcreator/web/index.html
+++ b/qb-jobcreator/web/index.html
@@ -109,6 +109,13 @@
     </div>
   </div>
 
+  <!-- Panel de Crafteo -->
+  <div id="craft" class="craft hidden">
+    <div class="craft-panel">
+      <div id="craft-list"></div>
+    </div>
+  </div>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/qb-jobcreator/web/style.css
+++ b/qb-jobcreator/web/style.css
@@ -42,3 +42,13 @@ body{margin:0;background:transparent;color:var(--text);font:14px/1.4 Inter,syste
 .input,select,textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #2a3146;background:#0f1422;color:#e5e7eb}
 .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
 .actions-inline{display:flex;gap:6px}
+
+/* ===== Crafteo ===== */
+.craft.hidden{display:none!important}
+.craft{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.45);z-index:9999}
+.craft-panel{background:var(--card);padding:20px;border-radius:12px;max-height:80vh;overflow-y:auto;min-width:320px}
+.craft-item{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.craft-item img{width:64px;height:64px;object-fit:contain;border-radius:6px}
+.craft-item .materials{flex:1;font-size:14px}
+.craft-item .materials ul{margin:0;padding-left:16px}
+.craft-item button{padding:8px 12px}


### PR DESCRIPTION
## Summary
- add crafting panel with item previews and materials
- replace qb-menu crafting with custom NUI
- hook NUI callbacks for selecting and crafting items

## Testing
- ⚠️ `luacheck qb-jobcreator/client/zones.lua` (command not found)
- ⚠️ `npm test` (no package.json)

------
https://chatgpt.com/codex/tasks/task_e_68ae174d948483268306f87bde19c877