### PR TITLE
feat: configurable clothing system

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -267,7 +267,13 @@ local function addTargetForZone(z)
       label = 'Vestuario', icon = 'fa-solid fa-shirt',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
-        if GetResourceState('illenium-appearance')=='started' then
+        local data = z.data or {}
+        local mode = data.mode
+        if mode == 'illenium' then
+          TriggerEvent('illenium-appearance:client:openWardrobe', {customization = {components = true, props = true}})
+        elseif mode == 'qb-clothing' then
+          TriggerEvent('qb-clothing:client:openMenu', true) -- true = shop mode
+        elseif GetResourceState('illenium-appearance')=='started' then
           -- tienda de ropa / vestuario
           TriggerEvent('illenium-appearance:client:openWardrobe', {customization = {components = true, props = true}})
         elseif GetResourceState('qb-clothing')=='started' then


### PR DESCRIPTION
## Summary
- allow cloakroom zones to read `z.data.mode` for wardrobe selection

## Testing
- `luac -p qb-jobcreator/client/zones.lua`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ae495e19708326ac99b7eb65e57e05