### PR TITLE
fix: preserve primary job when removing secondary

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -445,12 +445,14 @@ RegisterNetEvent('qb-jobcreator:server:fire', function(jobName, citizenid)
     if Player.PlayerData.citizenid == citizenid then
       if Player.PlayerData.job and Player.PlayerData.job.name == jobName then
         Player.Functions.SetJob('unemployed', 0)
+      elseif Config.MultiJob and Config.MultiJob.Enabled then
+        -- despedir un trabajo secundario no debe afectar al principal
       end
       Multi_Remove(citizenid, jobName)
       return
     end
   end
-  DB.UpdateOfflineJob(citizenid, 'unemployed', 0)
+  DB.UpdateOfflineJob(citizenid, 'unemployed', 0, jobName)
   Multi_Remove(citizenid, jobName)
 end)
 


### PR DESCRIPTION
## Summary
- prevent demotions from removing a player's primary job when removing secondary roles
- check offline multijob data before setting job to unemployed

## Testing
- `luacheck qb-jobcreator/server/main.lua qb-jobcreator/server/db.lua` *(247 warnings / 0 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae504ee5ec8326b2a6a623404662ff