### PR TITLE
Include duty and whitelist fields for jobs

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -22,7 +22,14 @@ end
 
 -- ===== Helpers =====
 local function InjectJobToCore(job)
-  QBCore.Shared.Jobs[job.name] = { label = job.label, grades = job.grades }
+  QBCore.Shared.Jobs[job.name] = {
+    label = job.label,
+    type = job.type or 'generic',
+    defaultDuty = job.defaultDuty ~= false,
+    offDutyPay = job.offDutyPay == true,
+    whitelisted = job.whitelisted or false,
+    grades = job.grades or {}
+  }
 end
 
 local function MultiAvailable()
@@ -231,6 +238,8 @@ RegisterNetEvent('qb-jobcreator:server:createJob', function(data)
     name = name,
     label = data.label or 'Trabajo',
     type = data.type or 'generic',
+    defaultDuty = data.defaultDuty ~= false,
+    offDutyPay = data.offDutyPay == true,
     whitelisted = data.whitelisted or false,
     grades = next(data.grades or {}) and data.grades or Config.DefaultGrades,
     actions = {


### PR DESCRIPTION
## Summary
- Register type, default duty, off-duty pay, whitelist, and grades when injecting jobs into QBCore
- Capture default duty and off-duty pay values when creating new jobs

## Testing
- `lua -e "assert(loadfile('qb-jobcreator/server/main.lua'))"`


------
https://chatgpt.com/codex/tasks/task_e_68ae51b8f1088326bd716b0e5a7eb4e3