### PR TITLE
Persist job changes to qb-core jobs file

### DIFF
--- a/qb-jobcreator/fxmanifest.lua
+++ b/qb-jobcreator/fxmanifest.lua
@@ -39,5 +39,6 @@ client_scripts {
 server_scripts {
   '@oxmysql/lib/MySQL.lua',
   'server/db.lua',
+  'server/jobsfile.lua',
   'server/main.lua',
 }

--- a/qb-jobcreator/server/jobsfile.lua
+++ b/qb-jobcreator/server/jobsfile.lua
@@ -1,0 +1,58 @@
+JobsFile = JobsFile or {}
+local JobsFile = JobsFile
+
+local RESOURCE = 'qb-core'
+local FILE = 'shared/jobs.lua'
+
+function JobsFile.Load()
+  local content = LoadResourceFile(RESOURCE, FILE)
+  if not content then return {}, true end
+  local env = { QBShared = {} }
+  local fn, err = load(content, '@'..FILE, 't', env)
+  if not fn then print('JobsFile.Load error:', err) return {}, true end
+  local ok, execErr = pcall(fn)
+  if not ok then print('JobsFile.Load exec error:', execErr) return {}, true end
+  return env.QBShared.Jobs or {}, env.QBShared.ForceJobDefaultDutyAtLogin
+end
+
+local function serialize(val, indent)
+  indent = indent or 0
+  local t = type(val)
+  if t == 'table' then
+    local lines = {'{\n'}
+    local keys = {}
+    for k in pairs(val) do keys[#keys+1] = k end
+    table.sort(keys, function(a,b) return tostring(a) < tostring(b) end)
+    for _, k in ipairs(keys) do
+      local key
+      if type(k) == 'string' and k:match('^%a[%w_]*$') then
+        key = k .. ' = '
+      else
+        key = '[' .. string.format('%q', k) .. '] = '
+      end
+      lines[#lines+1] = string.rep('  ', indent+1) .. key .. serialize(val[k], indent+1) .. ',\n'
+    end
+    lines[#lines+1] = string.rep('  ', indent) .. '}'
+    return table.concat(lines)
+  elseif t == 'string' then
+    return string.format('%q', val)
+  elseif t == 'number' or t == 'boolean' then
+    return tostring(val)
+  else
+    return 'nil'
+  end
+end
+
+function JobsFile.Save(jobs)
+  jobs = jobs or (QBCore and QBCore.Shared and QBCore.Shared.Jobs) or {}
+  local force = QBCore and QBCore.Shared and QBCore.Shared.ForceJobDefaultDutyAtLogin
+  local lines = {}
+  lines[#lines+1] = 'QBShared = QBShared or {}'
+  if force ~= nil then
+    lines[#lines+1] = 'QBShared.ForceJobDefaultDutyAtLogin = ' .. tostring(force)
+  end
+  lines[#lines+1] = 'QBShared.Jobs = ' .. serialize(jobs, 0)
+  SaveResourceFile(RESOURCE, FILE, table.concat(lines, '\n') .. '\n', -1)
+end
+
+return JobsFile

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -1,5 +1,6 @@
 local DB = _G.DB
 QBCore = exports['qb-core']:GetCoreObject()
+local JobsFile = _G.JobsFile
 
 local Runtime = { Jobs = {}, Zones = {} }
 local _lastCreate = {}
@@ -252,6 +253,7 @@ RegisterNetEvent('qb-jobcreator:server:createJob', function(data)
   Runtime.Jobs[job.name] = job
   DB.SaveJob(job)
   InjectJobToCore(job)
+  JobsFile.Save()
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
 end)
 
@@ -260,6 +262,7 @@ RegisterNetEvent('qb-jobcreator:server:deleteJob', function(name)
   Runtime.Jobs[name] = nil
   QBCore.Shared.Jobs[name] = nil
   DB.DeleteJob(name)
+  JobsFile.Save()
   local zones = {}
   for _, z in ipairs(Runtime.Zones) do
     if z.job ~= name then zones[#zones+1] = z end
@@ -273,7 +276,7 @@ RegisterNetEvent('qb-jobcreator:server:duplicateJob', function(name, newName)
   local src = source; if not ensurePerm(src) then return end
   local j = Runtime.Jobs[name]; if not j then return end
   local copy = json.decode(json.encode(j)); copy.name = newName; copy.label = copy.label .. ' (Copia)'
-  Runtime.Jobs[newName] = copy; DB.SaveJob(copy); InjectJobToCore(copy)
+  Runtime.Jobs[newName] = copy; DB.SaveJob(copy); InjectJobToCore(copy); JobsFile.Save()
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
 end)
 
@@ -288,7 +291,7 @@ RegisterNetEvent('qb-jobcreator:server:addGrade', function(jobName, gradeKey, da
     payment = tonumber(data and data.payment) or 0,
     isboss = data and (data.isboss == true) or false
   }
-  DB.SaveJob(j); InjectJobToCore(j)
+  DB.SaveJob(j); InjectJobToCore(j); JobsFile.Save()
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
 end)
 
@@ -302,7 +305,7 @@ RegisterNetEvent('qb-jobcreator:server:updateGrade', function(jobName, gradeKey,
     if data.payment ~= nil then g.payment = tonumber(data.payment) or 0 end
     if data.isboss ~= nil then g.isboss = data.isboss == true end
   end
-  DB.SaveJob(j); InjectJobToCore(j)
+  DB.SaveJob(j); InjectJobToCore(j); JobsFile.Save()
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
 end)
 
@@ -310,7 +313,7 @@ RegisterNetEvent('qb-jobcreator:server:deleteGrade', function(jobName, gradeKey)
   local src = source; if not ensurePerm(src) then return end
   local j = Runtime.Jobs[jobName]; if not j then return end
   if j.grades then j.grades[tostring(gradeKey)] = nil end
-  DB.SaveJob(j); InjectJobToCore(j)
+  DB.SaveJob(j); InjectJobToCore(j); JobsFile.Save()
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
 end)
 


### PR DESCRIPTION
## Summary
- add `jobsfile` module to read/write `qb-core/shared/jobs.lua`
- sync `QBCore.Shared.Jobs` to file after job or grade changes
- include new server script in fxmanifest

## Testing
- `luacheck qb-jobcreator` *(warnings: 668)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5509a7c0832685bfbe19db4e05a0