### PR TITLE
Avoid qb-target errors when zone has no interactions

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -425,11 +425,15 @@ local function addTargetForZone(z)
     })
   end
 
-  exports['qb-target']:AddBoxZone(name, vector3(z.coords.x, z.coords.y, z.coords.z), size, size, {
-    name = name, heading = 0.0, minZ = z.coords.z-1.0, maxZ = z.coords.z+2.0
-  }, { options = opts, distance = radius + 0.5 })
+  if #opts > 0 then
+    exports['qb-target']:AddBoxZone(name, vector3(z.coords.x, z.coords.y, z.coords.z), size, size, {
+      name = name, heading = 0.0, minZ = z.coords.z-1.0, maxZ = z.coords.z+2.0
+    }, { options = opts, distance = radius + 0.5 })
 
-  z._zoneName = name
+    z._zoneName = name
+  else
+    print(string.format('[qb-jobcreator] Zona %s sin interacciones, se omite qb-target', name))
+  end
 end
 
 RegisterNetEvent('qb-jobcreator:client:teleportSelect', function(data)


### PR DESCRIPTION
## Summary
- Skip creating qb-target zones without options
- Log a console warning when a zone has no interactions

## Testing
- `luac -p qb-jobcreator/client/zones.lua`
- `lua - <<'EOF'
local opts = {}
local name = 'testzone'
local z = { coords = { x = 0, y = 0, z = 0 } }
local radius = 1.0
local size = radius * 2.0
vector3 = function(x,y,z) return { x = x, y = y, z = z } end
exports = { ['qb-target'] = { AddBoxZone = function(...) print('AddBoxZone called') end } }
if #opts > 0 then
  exports['qb-target']:AddBoxZone(name, vector3(z.coords.x, z.coords.y, z.coords.z), size, size, {
    name = name, heading = 0.0, minZ = z.coords.z-1.0, maxZ = z.coords.z+2.0
  }, { options = opts, distance = radius + 0.5 })
else
  print(string.format('[qb-jobcreator] Zona %s sin interacciones, se omite qb-target', name))
end
EOF`
- `lua - <<'EOF'
local opts = {{}}
local name = 'testzone'
local z = { coords = { x = 0, y = 0, z = 0 } }
local radius = 1.0
local size = radius * 2.0
vector3 = function(x,y,z) return { x = x, y = y, z = z } end
exports = { ['qb-target'] = { AddBoxZone = function(...) print('AddBoxZone called') end } }
if #opts > 0 then
  exports['qb-target']:AddBoxZone(name, vector3(z.coords.x, z.coords.y, z.coords.z), size, size, {
    name = name, heading = 0.0, minZ = z.coords.z-1.0, maxZ = z.coords.z+2.0
  }, { options = opts, distance = radius + 0.5 })
else
  print(string.format('[qb-jobcreator] Zona %s sin interacciones, se omite qb-target', name))
end
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68ae7193da548326adbde118d7352053