### PR TITLE
Use Illenium clothing shop menu in cloakroom zone

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -270,12 +270,12 @@ local function addTargetForZone(z)
         local data = z.data or {}
         local mode = data.mode
         if mode == 'illenium' then
-          TriggerEvent('illenium-appearance:client:openWardrobe', {customization = {components = true, props = true}})
+          TriggerEvent('illenium-appearance:client:openClothingShopMenu')
         elseif mode == 'qb-clothing' then
           TriggerEvent('qb-clothing:client:openMenu', true) -- true = shop mode
         elseif GetResourceState('illenium-appearance')=='started' then
           -- tienda de ropa / vestuario
-          TriggerEvent('illenium-appearance:client:openWardrobe', {customization = {components = true, props = true}})
+          TriggerEvent('illenium-appearance:client:openClothingShopMenu')
         elseif GetResourceState('qb-clothing')=='started' then
           TriggerEvent('qb-clothing:client:openMenu', true) -- true = shop mode
         else


### PR DESCRIPTION
## Summary
- trigger Illenium appearance clothing shop menu from cloakroom zones
- retain qb-clothing fallback for servers using that menu

## Testing
- `luac -p qb-jobcreator/client/zones.lua`


------
https://chatgpt.com/codex/tasks/task_e_68ae9666a9b08326a305162298089ef2