### PR TITLE
Sync jobcreator zones on player load

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -128,6 +128,13 @@ AddEventHandler('onResourceStart', function(res)
   DB.EnsureSchema(); LoadAll()
 end)
 
+AddEventHandler('QBCore:Server:PlayerLoaded', function(Player)
+  local src = Player and Player.PlayerData and Player.PlayerData.source
+  if not src then return end
+  TriggerClientEvent('qb-jobcreator:client:syncAll', src, Runtime.Jobs, Runtime.Zones)
+  TriggerClientEvent('qb-jobcreator:client:rebuildZones', src, Runtime.Zones)
+end)
+
 -- Verifica permisos de administrador o jefe del trabajo especificado
 local function ensurePerm(src, job)
   -- primero, permisos globales


### PR DESCRIPTION
## Summary
- sync jobcreator data for new players by handling `QBCore:Server:PlayerLoaded`

## Testing
- `luac -p qb-jobcreator/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68aeb50f6a88832695c260224abf54c4