### PR TITLE
Detect inventory backend at runtime

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -237,7 +237,7 @@ local function addTargetForZone(z)
       label = 'Abrir Almacén', icon = 'fa-solid fa-box',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
-        TriggerServerEvent('qb-jobcreator:server:openStash', z.id, Config.Integrations.UseQbInventory and 'qb' or 'ox')
+        TriggerServerEvent('qb-jobcreator:server:openStash', z.id)
       end
     })
 
@@ -295,7 +295,7 @@ local function addTargetForZone(z)
       label = 'Abrir tienda', icon = 'fa-solid fa-store',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
-        TriggerServerEvent('qb-jobcreator:server:openShop', z.id, Config.Integrations.UseQbInventory and 'qb' or 'ox')
+        TriggerServerEvent('qb-jobcreator:server:openShop', z.id)
       end
     })
 

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -637,7 +637,8 @@ RegisterNetEvent('qb-jobcreator:server:openStash', function(zoneId)
   local stashId = ('jc_%s_%s'):format(zone.job, zone.id)
   local slots = tonumber(zone.data and zone.data.slots) or 50
   local maxWeight = tonumber(zone.data and zone.data.weight) or 400000
-  if Config.Integrations.UseQbInventory then
+  local useQb = GetResourceState('qb-inventory') == 'started'
+  if useQb then
     TriggerClientEvent('inventory:client:SetCurrentStash', src, stashId)
     pcall(function() exports['qb-inventory']:OpenStash(src, stashId, slots, maxWeight, true) end)
   else
@@ -652,7 +653,8 @@ RegisterNetEvent('qb-jobcreator:server:openShop', function(zoneId)
   if not ok then return end
   local sid = ('jc_shop_%s_%s'):format(zone.job, zone.id)
   local items = SanitizeShopItems(zone.data and zone.data.items or {})
-  if Config.Integrations.UseQbInventory then
+  local useQb = GetResourceState('qb-inventory') == 'started'
+  if useQb then
     local shopItems = {}
     for _, it in ipairs(items) do
       shopItems[#shopItems+1] = { name = it.name, price = it.price, amount = it.count, info = it.info }


### PR DESCRIPTION
## Summary
- remove client-side inventory backend selection parameters when opening stash or shop
- dynamically choose qb-inventory or ox_inventory on the server based on resource state

## Testing
- ⚠️ `luacheck .` (command not found)
- ⚠️ `npm test` (package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68af11a4e2808326b57b1b36fa0d4edc