### PR TITLE
Add inventory compatibility for ambulance stashes

### DIFF
--- a/ars_ambulancejob/client/job/stashes.lua
+++ b/ars_ambulancejob/client/job/stashes.lua
@@ -3,6 +3,23 @@ local IsControlJustReleased = IsControlJustReleased
 local CreateThread          = CreateThread
 
 
+local function OpenStash(id, data)
+    if GetResourceState('ox_inventory') == 'started' then
+        TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, data)
+    else
+        if GetResourceState('qb-inventory') == 'started' then
+            TriggerServerEvent('qb-inventory:server:OpenInventory', 'stash', id, {maxweight = data.weight, slots = data.slots})
+        else
+            local inv = exports['qb-inventory']
+            if inv and inv.OpenStash then
+                inv:OpenStash(id, data.slots, data.weight)
+            end
+        end
+        TriggerEvent('inventory:client:SetCurrentStash', id)
+    end
+end
+
+
 local function createStashes()
     for index, hospital in pairs(Config.Hospitals) do
         for id, stash in pairs(hospital.stash) do
@@ -22,8 +39,7 @@ local function createStashes()
                         DrawMarker(2, self.coords.x, self.coords.y, self.coords.z, 0.0, 0.0, 0.0, 180.0, 0.0, 0.0, 0.2, 0.2, 0.2, 199, 208, 209, 100, true, true, 2, nil, nil, false)
 
                         if IsControlJustReleased(0, 38) then
-                            TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, {maxweight = stash.weight * 1000, slots = stash.slots})
-                            TriggerEvent('inventory:client:SetCurrentStash', id)
+                            OpenStash(id, { slots = stash.slots, weight = stash.weight * 1000 })
                         end
                     end
                 end,


### PR DESCRIPTION
## Summary
- add `OpenStash` helper to detect `ox_inventory` or `qb-inventory`
- use helper when opening ambulance stashes

## Testing
- `luacheck ars_ambulancejob/client/job/stashes.lua`


------
https://chatgpt.com/codex/tasks/task_e_68af16849d3c8326970f18b9b2b342db