### PR TITLE
feat(qb): handle qb inventory open event

### DIFF
--- a/ox_inventory/modules/bridge/qb/client.lua
+++ b/ox_inventory/modules/bridge/qb/client.lua
@@ -131,3 +131,27 @@ end)
 RegisterNetEvent('inventory:client:SetCurrentStash', function(name)
     currentStash = name
 end)
+
+RegisterNetEvent('qb-inventory:client:openInventory', function(items, other)
+    local invType = 'player'
+    local invId
+
+    if type(other) == 'table' then
+        invType = other.type or invType
+        invId = other.name or other.id
+
+        if invId and not other.type then
+            if invId:find('stash%-') then
+                invType = 'stash'
+            elseif invId:find('shop%-') then
+                invType = 'shop'
+            elseif invId:find('trunk%-') then
+                invType = 'trunk'
+            elseif invId:find('glovebox%-') then
+                invType = 'glovebox'
+            end
+        end
+    end
+
+    exports.ox_inventory:openInventory(invType, invId)
+end)


### PR DESCRIPTION
## Summary
- bridge `qb-inventory:client:openInventory` to ox_inventory
- detect and open stash, shop, trunk, or glovebox inventories

## Testing
- ⚠️ `npm test` (missing package.json)
- ⚠️ `luacheck ox_inventory/modules/bridge/qb/client.lua` (luacheck not installed)


------
https://chatgpt.com/codex/tasks/task_e_68af183b552483269266b939a7f2f2ed