### PR TITLE
feat: add inventory stash wrapper

### DIFF
--- a/ars_ambulancejob/client/job/medical_bag.lua
+++ b/ars_ambulancejob/client/job/medical_bag.lua
@@ -15,7 +15,7 @@ local function openMedicalBag()
 
     lib.callback('ars_ambulancejob:openMedicalBag', false, function(stash)
         TriggerServerEvent('inventory:server:OpenInventory', 'stash', stash, {maxweight = 50 * 1000, slots = 10})
-        TriggerEvent('inventory:client:SetCurrentStash', stash)
+        SetCurrentStash(stash)
     end)
 end
 

--- a/ars_ambulancejob/client/job/stashes.lua
+++ b/ars_ambulancejob/client/job/stashes.lua
@@ -3,6 +3,17 @@ local IsControlJustReleased = IsControlJustReleased
 local CreateThread          = CreateThread
 
 
+function SetCurrentStash(id)
+    if GetResourceState('ox_inventory') == 'started' then
+        TriggerEvent('inventory:client:SetCurrentStash', id)
+    elseif GetResourceState('qb-inventory') == 'started' then
+        TriggerEvent('qb-inventory:client:SetCurrentStash', id)
+    else
+        TriggerEvent('inventory:client:SetCurrentStash', id)
+    end
+end
+
+
 local function OpenStash(id, data)
     if GetResourceState('ox_inventory') == 'started' then
         TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, data)
@@ -15,8 +26,9 @@ local function OpenStash(id, data)
                 inv:OpenStash(id, data.slots, data.weight)
             end
         end
-        TriggerEvent('inventory:client:SetCurrentStash', id)
     end
+
+    SetCurrentStash(id)
 end
 
 


### PR DESCRIPTION
## Summary
- add SetCurrentStash wrapper emitting proper inventory event
- use SetCurrentStash in medical bag and stash logic

## Testing
- `luac -p ars_ambulancejob/client/job/stashes.lua`
- `luac -p ars_ambulancejob/client/job/medical_bag.lua`


------
https://chatgpt.com/codex/tasks/task_e_68af187940bc83268737fe1a4dc2ee4d