### PR TITLE
feat: auto-detect framework

### DIFF
--- a/ox_inventory/init.lua
+++ b/ox_inventory/init.lua
@@ -12,9 +12,23 @@ end
 -- You want to change resource settings? Use convars (and by that we mean a entirely seperate cfg file included that you execute in the server cfg).
 -- https://coxdocs.dev/ox_inventory#config
 
+local framework = GetConvar('inventory:framework', '')
+
+if framework == '' then
+    if GetResourceState('qbx_core'):find('start') then
+        framework = 'qbx'
+    elseif GetResourceState('ox_core'):find('start') then
+        framework = 'ox'
+    elseif GetResourceState('qb-core'):find('start') then
+        framework = 'qb'
+    else
+        framework = 'qb'
+    end
+end
+
 shared = {
     resource = GetCurrentResourceName(),
-    framework = GetConvar('inventory:framework', 'qb'),
+    framework = framework,
     playerslots = GetConvarInt('inventory:slots', 50),
     playerweight = GetConvarInt('inventory:weight', 30000),
     target = GetConvarInt('inventory:target', 0) == 1,


### PR DESCRIPTION
## Summary
- detect qb, qbx, or ox frameworks when `inventory:framework` convar is unset

## Testing
- `luac -p ox_inventory/init.lua` *(fails: unexpected symbol near '`')*

------
https://chatgpt.com/codex/tasks/task_e_68af193525088326a8ad34f6f301bf77