### PR TITLE
feat(bridge): add cross-framework stash and shop wrappers

### DIFF
--- a/ox_inventory/README.md
+++ b/ox_inventory/README.md
@@ -65,6 +65,20 @@ We do not guarantee compatibility or support for third-party resources.
 - [ox_core](https://github.com/communityox/ox_core)
 - [nd_core](https://github.com/ND-Framework/ND_Core)
 
+## Wrapper exports
+
+To simplify cross-resource integrations, `ox_inventory` provides generic server exports
+that automatically call the appropriate inventory system based on `shared.framework`.
+Scripts should prefer these helpers over directly invoking a specific inventory API.
+
+```lua
+-- open a stash for a player
+exports.ox_inventory:OpenStash(source, 'mystash')
+
+-- open a registered shop
+exports.ox_inventory:OpenShop(source, 'twentyfourseven')
+```
+
 ## ✨ Features
 
 - Server-side security ensures interactions with items, shops, and stashes are all validated.

--- a/ox_inventory/modules/bridge/server.lua
+++ b/ox_inventory/modules/bridge/server.lua
@@ -56,3 +56,20 @@ if not success then
 end
 
 if server.convertInventory then exports('ConvertItems', server.convertInventory) end
+
+exports('OpenStash', function(src, id, opts)
+    if shared.framework == 'qb' then
+        local o = opts or {}
+        return exports['qb-inventory']:OpenStash(src, id, o.slots, o.weight, o.owner, o.groups)
+    end
+
+    return exports.ox_inventory:forceOpenInventory(src, 'stash', id)
+end)
+
+exports('OpenShop', function(src, id)
+    if shared.framework == 'qb' then
+        return exports['qb-inventory']:OpenShop(src, id)
+    end
+
+    return exports.ox_inventory:forceOpenInventory(src, 'shop', id)
+end)


### PR DESCRIPTION
## Summary
- provide `OpenStash` and `OpenShop` exports that route to qb-inventory or ox_inventory depending on `shared.framework`
- document the new wrapper exports for use by other scripts

## Testing
- `npm test` *(fails: package.json missing)*
- `luacheck modules/bridge/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af1c984d18832697fb0c3c8fe301a1