### PR TITLE
Initialize missing QBCore money accounts during player setup

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -47,7 +47,13 @@ local function setupPlayer(Player)
     Player.PlayerData.name = ('%s %s'):format(Player.PlayerData.charinfo.firstname, Player.PlayerData.charinfo.lastname)
     server.setPlayerInventory(Player.PlayerData)
 
-    Inventory.SetItem(Player.PlayerData.source, 'money', Player.PlayerData.money.cash)
+    for account in pairs(server.accounts) do
+        local key = account == 'money' and 'cash' or account
+        local amount = Player.PlayerData.money[key] or 0
+
+        Player.PlayerData.money[key] = amount
+        Inventory.SetItem(Player.PlayerData.source, account, amount)
+    end
 
     QBCore.Functions.AddPlayerMethod(Player.PlayerData.source, "AddItem", function(item, amount, slot, info)
         return Inventory.AddItem(Player.PlayerData.source, item, amount, info, slot)


### PR DESCRIPTION
## Summary
- Set inventory account items for each configured account when a player loads
- Initialize absent money accounts to zero to avoid nil errors

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af21822fe083269d1d484c48ba09a4