### PR TITLE
Use events to open jobcreator shops

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -60,6 +60,15 @@ RegisterNetEvent('qb-jobcreator:client:openBossUI', function(job)
   end)
 end)
 
+-- Abre una tienda registrada en qb-inventory u ox_inventory
+RegisterNetEvent('qb-jobcreator:client:openInvShop', function(id, useServerEvent)
+  if useServerEvent then
+    TriggerServerEvent('qb-inventory:server:OpenShop', id)
+  else
+    TriggerEvent('qb-inventory:client:OpenShop', id)
+  end
+end)
+
 RegisterNUICallback('close', function(_, cb) ForceClose(); cb(true) end)
 
 -- ===== CRUD Trabajos =====

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -664,7 +664,10 @@ RegisterNetEvent('qb-jobcreator:server:openShop', function(zoneId)
         exports['qb-inventory']:CreateShop({ name = sid, label = zone.label or 'Shop', items = shopItems })
         CreatedShops[sid] = true
       end
-      exports['qb-inventory']:OpenShop(src, sid)
+      local ver = GetResourceMetadata('qb-inventory', 'version', 0) or '0'
+      local major = tonumber(ver:match('^(%d+)')) or 0
+      local useServerEvent = major >= 2
+      TriggerClientEvent('qb-jobcreator:client:openInvShop', src, sid, useServerEvent)
     end)
   else
     for _, it in ipairs(items) do


### PR DESCRIPTION
## Summary
- Replace deprecated qb-inventory `OpenShop` export with version-aware event call
- Allow clients to open shops through `qb-jobcreator:client:openInvShop`

## Testing
- `lua -v`
- `luac -p qb-jobcreator/server/main.lua`
- `luac -p qb-jobcreator/client/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68af8bde428483268991e25cef00f9f9