### PR TITLE
Use ApplyDamageToPed for hunger/thirst damage

### DIFF
--- a/qb-core/client/loops.lua
+++ b/qb-core/client/loops.lua
@@ -16,7 +16,10 @@ CreateThread(function()
                 local ped = PlayerPedId()
                 local currentHealth = GetEntityHealth(ped)
                 local decreaseThreshold = math.random(5, 10)
-                SetEntityHealth(ped, currentHealth - decreaseThreshold)
+                ApplyDamageToPed(ped, decreaseThreshold)
+                if currentHealth - decreaseThreshold <= 0 then
+                    TriggerServerEvent('ars_ambulancejob:updateDeathStatus', { isDead = true })
+                end
             end
         end
         Wait(QBCore.Config.StatusInterval)


### PR DESCRIPTION
## Summary
- apply damage with `ApplyDamageToPed` so hunger/thirst damage triggers events
- notify `ars_ambulancejob` when damage kills the player

## Testing
- `luac -p qb-core/client/loops.lua`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68afd5e645a88326b756c2d802eb83b0