### PR TITLE
Cap hunger and thirst reset values in ambulance job

### DIFF
--- a/ars_ambulancejob/client/bridge/qb.lua
+++ b/ars_ambulancejob/client/bridge/qb.lua
@@ -144,9 +144,10 @@ end
 
 function healStatus()
     local playerData = QBCore.Functions.GetPlayerData()
+    local safeValue = 100
 
-    TriggerServerEvent('consumables:server:addHunger', playerData.metadata.hunger + 100000)
-    TriggerServerEvent('consumables:server:addThirst', playerData.metadata.hunger + 100000)
+    TriggerServerEvent('consumables:server:addHunger', safeValue - playerData.metadata.hunger)
+    TriggerServerEvent('consumables:server:addThirst', safeValue - playerData.metadata.thirst)
 end
 
 function playerSpawned()


### PR DESCRIPTION
## Summary
- Fix thirst event to use thirst metadata
- Restore hunger and thirst to a safe maximum rather than adding huge values

## Testing
- `luacheck ars_ambulancejob/client/bridge/qb.lua` *(fails: command not found)*
- `lua -p ars_ambulancejob/client/bridge/qb.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afd7637ec48326b89242eaa6d116db