### PR TITLE
refactor: localize data variable in qb bridge

### DIFF
--- a/ars_ambulancejob/client/bridge/qb.lua
+++ b/ars_ambulancejob/client/bridge/qb.lua
@@ -26,6 +26,7 @@ function toggleClothes(toggle, clothes)
 
         if Config.ClothingScript and Config.ClothingScript ~= 'core' then
             local model = GetEntityModel(playerPed)
+            local data
 
             if model == GetHashKey('mp_m_freemode_01') then
                 data = clothes.male[jobGrade] or clothes.male[1]


### PR DESCRIPTION
## Summary
- ensure `data` table in `toggleClothes` is local to prevent global leakage

## Testing
- `luac -p ars_ambulancejob/client/bridge/qb.lua`


------
https://chatgpt.com/codex/tasks/task_e_68afd828927483269ddfaee34d8b5b20