### PR TITLE
Use data target for status updates in qb bridge

### DIFF
--- a/ars_ambulancejob/server/bridge/qb.lua
+++ b/ars_ambulancejob/server/bridge/qb.lua
@@ -32,14 +32,14 @@ function updateStatus(data)
 
     Player.Functions.SetMetaData("isdead", data.status)
 
-    if not player[source] then
-        player[source] = {}
+    if not player[data.target] then
+        player[data.target] = {}
     end
 
-    player[source].isDead = data.status
+    player[data.target].isDead = data.status
 
     if data.status == true then
-        player[source].killedBy = data.killedBy
+        player[data.target].killedBy = data.killedBy
     end
 end
 


### PR DESCRIPTION
## Summary
- replace player[source] with player[data.target] in updateStatus
- remove implicit source dependence for manual/test calls

## Testing
- `luacheck ars_ambulancejob/server/bridge/qb.lua`


------
https://chatgpt.com/codex/tasks/task_e_68afe7cc3ed48326a34e716a23693c47