### PR TITLE
feat: support multiple inventories in HasItem

### DIFF
--- a/qb-core/client/functions.lua
+++ b/qb-core/client/functions.lua
@@ -47,19 +47,36 @@ end
 function QBCore.Functions.HasItem(items, amount)
     amount = amount or 1
 
-    if type(items) == 'table' then
-        for _, v in pairs(items) do
-            local name = v.name or v
-            local meta = v.metadata
-            if exports.ox_inventory:GetItemCount(name, meta) < amount then
-                return false
-            end
-        end
+    local oxInv = GetResourceState('ox_inventory') == 'started'
+    local qbInv = GetResourceState('qb-inventory') == 'started'
 
-        return true
-    else
-        return exports.ox_inventory:GetItemCount(items) >= amount
+    if oxInv then
+        if type(items) == 'table' then
+            for _, v in pairs(items) do
+                local name = v.name or v
+                local meta = v.metadata
+                if exports.ox_inventory:GetItemCount(name, meta) < amount then
+                    return false
+                end
+            end
+
+            return true
+        else
+            return exports.ox_inventory:GetItemCount(items) >= amount
+        end
+    elseif qbInv then
+        if type(items) == 'table' then
+            local itemTable = {}
+            for _, v in pairs(items) do
+                itemTable[#itemTable + 1] = v.name or v
+            end
+            return exports['qb-inventory']:HasItem(itemTable, amount)
+        else
+            return exports['qb-inventory']:HasItem(items, amount)
+        end
     end
+
+    return false
 end
 
 ---Returns the full character name


### PR DESCRIPTION
## Summary
- handle ox_inventory and qb-inventory in `QBCore.Functions.HasItem`
- return false when no supported inventory is running to avoid errors

## Testing
- `luacheck qb-core/client/functions.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afec0d798483269d3d07a13ced47e9