### PR TITLE
feat: refactor stash handling to support ox and qb inventory

### DIFF
--- a/ars_ambulancejob/client/job/stashes.lua
+++ b/ars_ambulancejob/client/job/stashes.lua
@@ -3,29 +3,27 @@ local IsControlJustReleased = IsControlJustReleased
 local CreateThread          = CreateThread
 
 
+local inventoryType = GetResourceState('ox_inventory') == 'started' and 'ox' or (GetResourceState('qb-inventory') == 'started' and 'qb' or nil)
+
+
 function SetCurrentStash(id)
-    if GetResourceState('ox_inventory') == 'started' then
-        TriggerEvent('inventory:client:SetCurrentStash', id)
-    elseif GetResourceState('qb-inventory') == 'started' then
+    if inventoryType == 'ox' then
+        TriggerEvent('ox_inventory:client:SetCurrentStash', id)
+    elseif inventoryType == 'qb' then
         TriggerEvent('qb-inventory:client:SetCurrentStash', id)
     else
-        TriggerEvent('inventory:client:SetCurrentStash', id)
+        lib.notify({ type = 'error', description = 'No inventory resource started' })
     end
 end
 
-
 local function OpenStash(id, data)
-    if GetResourceState('ox_inventory') == 'started' then
-        TriggerServerEvent('inventory:server:OpenInventory', 'stash', id, data)
+    if inventoryType == 'ox' then
+        TriggerServerEvent('ox_inventory:server:OpenInventory', 'stash', id, data)
+    elseif inventoryType == 'qb' then
+        TriggerServerEvent('qb-inventory:server:OpenInventory', 'stash', id, {maxweight = data.weight, slots = data.slots})
     else
-        if GetResourceState('qb-inventory') == 'started' then
-            TriggerServerEvent('qb-inventory:server:OpenInventory', 'stash', id, {maxweight = data.weight, slots = data.slots})
-        else
-            local inv = exports['qb-inventory']
-            if inv and inv.OpenStash then
-                inv:OpenStash(id, data.slots, data.weight)
-            end
-        end
+        lib.notify({ type = 'error', description = 'No inventory resource started' })
+        return
     end
 
     SetCurrentStash(id)


### PR DESCRIPTION
## Summary
- determine inventory resource once using `inventoryType`
- open and set stash using ox or qb inventory events
- notify when no inventory system is available

## Testing
- `luacheck ars_ambulancejob/client/job/stashes.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff89dafa4832699100cd68f1bc7e4