### PR TITLE
feat: add ox inventory shop support

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -62,10 +62,15 @@ end)
 
 -- Abre una tienda registrada en qb-inventory u ox_inventory
 RegisterNetEvent('qb-jobcreator:client:openInvShop', function(id, useServerEvent)
-  if useServerEvent then
-    TriggerServerEvent('qb-inventory:server:OpenShop', id)
+  local oxStarted = GetResourceState('ox_inventory') == 'started'
+  if oxStarted then
+    exports.ox_inventory:openInventory('shop', id)
   else
-    TriggerEvent('qb-inventory:client:OpenShop', id)
+    if useServerEvent then
+      TriggerServerEvent('qb-inventory:server:OpenShop', id)
+    else
+      TriggerEvent('qb-inventory:client:OpenShop', id)
+    end
   end
 end)
 


### PR DESCRIPTION
## Summary
- open jobcreator shops with ox_inventory when the resource is started
- fall back to qb-inventory logic if ox_inventory isn't running

## Testing
- `luac -p qb-jobcreator/client/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68affbd103e48326a7e368493b32c332