### PR TITLE
Inserta trabajos por defecto cuando la BD está vacía

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -137,7 +137,17 @@ end
 
 AddEventHandler('onResourceStart', function(res)
   if res ~= GetCurrentResourceName() then return end
-  DB.EnsureSchema(); LoadAll()
+  DB.EnsureSchema()
+  local existing = DB.GetJobs()
+  if not existing or #existing == 0 then
+    local jobs = JobsFile.Load()
+    for name, job in pairs(jobs) do
+      job.name = name
+      DB.SaveJob(job)
+      InjectJobToCore(job)
+    end
+  end
+  LoadAll()
 end)
 
 AddEventHandler('QBCore:Server:PlayerLoaded', function(Player)


### PR DESCRIPTION
## Resumen
- Verifica la base de datos en el arranque y carga los trabajos por defecto de `qb-core` si está vacía.
- Inserta e inyecta cada trabajo inicial mediante `DB.SaveJob` y `InjectJobToCore`.

## Testing
- `luac -p ServerRP/qb-jobcreator/server/main.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b0107006408326b68d14074750d46d