### PR TITLE
refactor: reuse global HasOpenPermission

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -80,15 +80,7 @@ local function Multi_Has(citizenid, job)
 end
 
 -- ===== Permisos genéricos (admin/ACE) =====
-local function HasOpenPermission(src)
-  -- ACE (recomendado)
-  if IsPlayerAceAllowed(src, 'qb-jobcreator.open') then return true end
-  -- Grupo/perm de QBCore
-  local P = QBCore.Functions.GetPlayer(src)
-  if not P or not P.PlayerData then return false end
-  local grp = P.PlayerData.group or P.PlayerData.permission
-  return grp == 'admin' or grp == 'god'
-end
+-- Usa la función HasOpenPermission global de shared/sh_utils.lua
 
 -- ===== Permiso admin O boss del job =====
 local function allowAdminOrBoss(src, job)


### PR DESCRIPTION
## Summary
- remove duplicate local HasOpenPermission and rely on shared implementation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0115ee8408326898a2b295c711006