### PR TITLE
Sanitize shop items and add tests

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -15,8 +15,12 @@ local function SanitizeShopItems(items)
       local name = it.name:lower()
       local price = math.floor(tonumber(it.price) or 0)
       local count = math.floor(tonumber(it.count or it.amount or 1) or 1)
-      local info = type(it.info) == 'table' and it.info or nil
-      list[#list+1] = { name = name, price = price, count = count, info = info }
+      price = math.max(price, 0)
+      count = math.max(count, 1)
+      if price > 0 and count > 0 then
+        local info = type(it.info) == 'table' and it.info or nil
+        list[#list+1] = { name = name, price = price, count = count, info = info }
+      end
     end
   end
   return list

--- a/qb-jobcreator/tests/sanitize_shop_items_test.lua
+++ b/qb-jobcreator/tests/sanitize_shop_items_test.lua
@@ -1,0 +1,28 @@
+local file = assert(io.open("qb-jobcreator/server/main.lua", "r"))
+local src = file:read("*a")
+file:close()
+
+local body = src:match("local function SanitizeShopItems%([^%)]*%)(.-)\nend")
+assert(body, "SanitizeShopItems function not found")
+
+local sanitize = load("return function(items)" .. body .. "\nend")()
+
+local function assertEqual(actual, expected, msg)
+  if actual ~= expected then
+    error((msg or "assertion failed") .. " (expected " .. tostring(expected) .. ", got " .. tostring(actual) .. ")", 2)
+  end
+end
+
+-- negative price -> discarded
+local result1 = sanitize({{name='apple', price=-5, count=2}})
+assertEqual(#result1, 0, "Item with negative price should be discarded")
+
+-- negative count -> sanitized to 1
+local result2 = sanitize({{name='banana', price=10, count=-3}})
+assertEqual(result2[1].count, 1, "Negative count should be sanitized to 1")
+
+-- zero price -> discarded
+local result3 = sanitize({{name='free', price=0, count=1}})
+assertEqual(#result3, 0, "Item with zero price should be discarded")
+
+print("All tests passed")


### PR DESCRIPTION
## Summary
- clamp shop item price to 0 and count to at least 1
- ignore items with invalid values
- add Lua tests to verify sanitization logic

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b012574660832696cef3a57d134987