### PR TITLE
feat(crafting): add crafting table removal event

### DIFF
--- a/RaySist-Crafting/client/main.lua
+++ b/RaySist-Crafting/client/main.lua
@@ -63,7 +63,7 @@ local function BuildCraftingTables(zones)
             end
         end
 
-        table.insert(activeTables, { model = model, object = obj })
+        table.insert(activeTables, { id = zone.id or zone.name, model = model, object = obj })
     end
 end
 
@@ -75,6 +75,26 @@ end)
 
 RegisterNetEvent('RaySist-Crafting:client:SyncZones', function(zones)
     BuildCraftingTables(zones or {})
+end)
+
+RegisterNetEvent('RaySist-Crafting:client:RemoveTable', function(tableId)
+    for i, tbl in ipairs(activeTables) do
+        if tbl.id == tableId then
+            exports['qb-target']:RemoveTargetModel(tbl.model)
+            if tbl.object and DoesEntityExist(tbl.object) then
+                DeleteObject(tbl.object)
+            end
+            table.remove(activeTables, i)
+            break
+        end
+    end
+
+    for i, tbl in ipairs(Config.CraftingTables) do
+        if tbl.id == tableId then
+            table.remove(Config.CraftingTables, i)
+            break
+        end
+    end
 end)
 
 -- Open crafting menu

--- a/RaySist-Crafting/server/main.lua
+++ b/RaySist-Crafting/server/main.lua
@@ -67,10 +67,13 @@ QBCore.Functions.CreateCallback('RaySist-Crafting:server:DeleteZone', function(s
     if not QBCore.Functions.HasPermission(source, 'admin') then return cb(false) end
     MySQL.query.await('DELETE FROM crafting_zones WHERE id = ?', { id })
     for i, z in ipairs(CraftingData.zones) do
-        if z.id == id then table.remove(CraftingData.zones, i) break end
+        if z.id == id then
+            table.remove(CraftingData.zones, i)
+            break
+        end
     end
     Config.CraftingTables = CraftingData.zones
-    TriggerClientEvent('RaySist-Crafting:client:SyncZones', -1, CraftingData.zones)
+    TriggerClientEvent('RaySist-Crafting:client:RemoveTable', -1, id)
     cb(true)
 end)
 


### PR DESCRIPTION
## Summary
- add client event `RaySist-Crafting:client:RemoveTable` to remove crafting table entity and qb-target entry
- broadcast removal from server when a crafting zone is deleted

## Testing
- `luac -p RaySist-Crafting/client/main.lua && luac -p RaySist-Crafting/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b01ada63b483269111ab17f68ea521