### PR TITLE
feat: enable ammo item reload

### DIFF
--- a/Browns-QBWeaponReload/README.md
+++ b/Browns-QBWeaponReload/README.md
@@ -10,7 +10,7 @@ Discord Server: https://discord.gg/dGRHNbX5xc
 
 [EXPORTS] (Reloads Weapon, CLIENT SIDED)
 
-exports['Browns-QBWeaponReload']:ReloadWeapon() 
+exports['Browns-QBWeaponReload']:ReloadWeapon()
 
 [INSTALLATION] (IF YOU NEED HELP SETTING UP, OR FEEL LIKE YOU MAY BREAK SOMETHING CONTACT ME AT MY DISCORD ABOVE)
 
@@ -30,36 +30,16 @@ find the 'weapons:client:AddAmmo' event (should be at around line 77) then DELET
 
 go to qb-weapons > server > main.lua 
 
-# STEP 5: 
+# STEP 5:
 
-delete all of the QBCore.Functions.CreateUsableItem functions (FOR AMMO ONLY) (Should be at about line: 304) 
+restore the QBCore.Functions.CreateUseableItem functions for each ammo type in `qb-weapons/server/main.lua` and make them trigger the new `inventory:client:UseAmmo` event. They should look like this:
 
-THE ONES THAT YOU WANT TO DELETE SHOULD LOOK LIKE THIS:
+```
+for ammoItem, _ in pairs(Config.AmmoTypes) do
+    QBCore.Functions.CreateUseableItem(ammoItem, function(source, item)
+        TriggerClientEvent('inventory:client:UseAmmo', source)
+    end)
+end
+```
 
-QBCore.Functions.CreateUseableItem('pistol_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_PISTOL', 12, item)
-end)
-
-QBCore.Functions.CreateUseableItem('rifle_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_RIFLE', 30, item)
-end)
-
-QBCore.Functions.CreateUseableItem('smg_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SMG', 20, item)
-end)
-
-QBCore.Functions.CreateUseableItem('shotgun_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SHOTGUN', 10, item)
-end)
-
-QBCore.Functions.CreateUseableItem('mg_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_MG', 30, item)
-end)
-
-QBCore.Functions.CreateUseableItem('snp_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_SNIPER', 10, item)
-end)
-
-QBCore.Functions.CreateUseableItem('emp_ammo', function(source, item)
-    TriggerClientEvent('weapons:client:AddAmmo', source, 'AMMO_EMPLAUNCHER', 10, item)
-end)
+Using an ammo item now calls the exported `ReloadWeapon` function. Players can still press **R** thanks to the key mapping in `client.lua`.

--- a/Browns-QBWeaponReload/code/client.lua
+++ b/Browns-QBWeaponReload/code/client.lua
@@ -67,6 +67,10 @@ function ReloadWeapon() -- Creating the reloading functionality
     end
 end
 
+RegisterNetEvent('inventory:client:UseAmmo', function()
+    ReloadWeapon()
+end)
+
 RegisterCommand('browns_reload', function(source) -- the reload function to create an export
     ReloadWeapon()
 end)

--- a/Browns-QBWeaponReload/code/server.lua
+++ b/Browns-QBWeaponReload/code/server.lua
@@ -2,10 +2,9 @@ local QBCore = exports['qb-core']:GetCoreObject()
 
 QBCore.Functions.CreateCallback('browns_reload:GetAmount', function(source, cb, types) -- Passing the amount of ammo the player has to the client
     local src = source 
-    local xPlayer = QBCore.Functions.GetPlayer(src)
-    local ammo_type = nil
-    local ammo_amounts = nil
-    local has_ammo = nil
+    local Player = QBCore.Functions.GetPlayer(src)
+    local ammo_type
+    local ammo_amounts
     if types == 'AMMO_PISTOL' then 
         ammo_type = 'pistol_ammo'
     elseif types == 'AMMO_SMG' then 
@@ -21,18 +20,39 @@ QBCore.Functions.CreateCallback('browns_reload:GetAmount', function(source, cb, 
     elseif types == 'AMMO_EMPLAUNCHER' then 
         ammo_type = 'emp_ammo'
     end
-    if ammo_type ~= nil then 
-        has_ammo = exports[tostring(config.inventory)]:HasItem(src, tostring(ammo_type), 1)
+
+    if ammo_type then
+        if config.inventory == 'ox_inventory' then
+            ammo_amounts = exports.ox_inventory:Search(src, 'count', ammo_type)
+            if ammo_amounts <= 0 then ammo_amounts = nil end
+        elseif config.inventory == 'ps-inventory' then
+            local item = exports['ps-inventory']:GetItemByName(src, ammo_type)
+            ammo_amounts = item and item.amount or nil
+        else -- qb-inventory and similar
+            local item = Player and Player.Functions.GetItemByName(ammo_type)
+            ammo_amounts = item and item.amount or nil
+        end
     end
-    if has_ammo then 
-        local ammo_items = exports[tostring(config.inventory)]:GetItemByName(src, tostring(ammo_type))
-        ammo_amounts = ammo_items.amount 
-    end
+
     cb(ammo_amounts, ammo_type)
 end)
 
 RegisterNetEvent('browns_reload:RemoveAmmoItem', function(ammo, counts) -- Removing reloaded ammo items from the player
-    local src = source 
-    local xPlayer = QBCore.Functions.GetPlayer(src)
-    xPlayer.Functions.RemoveItem(ammo, counts)
+    local src = source
+    counts = tonumber(counts)
+    local Player = QBCore.Functions.GetPlayer(src)
+
+    if config.inventory == 'ox_inventory' then
+        exports.ox_inventory:RemoveItem(src, ammo, counts)
+    elseif config.inventory == 'ps-inventory' then
+        local item = exports['ps-inventory']:GetItemByName(src, ammo)
+        if item and item.amount >= counts then
+            exports['ps-inventory']:RemoveItem(src, ammo, counts)
+        end
+    else
+        local item = Player and Player.Functions.GetItemByName(ammo)
+        if item and item.amount >= counts then
+            Player.Functions.RemoveItem(ammo, counts)
+        end
+    end
 end)

--- a/Browns-QBWeaponReload/config.lua
+++ b/Browns-QBWeaponReload/config.lua
@@ -1,8 +1,8 @@
 config = {}
 
 -- accepted inventories: --
--- 'qb-inventory' --
--- 'lj-inventory' -- 
--- 'ps-inventory' --
+-- 'qb-inventory'
+-- 'ps-inventory'
+-- 'ox_inventory'
 
 config.inventory = 'qb-inventory' 

--- a/qb-weapons/server/main.lua
+++ b/qb-weapons/server/main.lua
@@ -1,0 +1,9 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+-- Register ammo items as usable and trigger client reload
+for ammoItem, _ in pairs(Config.AmmoTypes or {}) do
+    QBCore.Functions.CreateUseableItem(ammoItem, function(source, item)
+        TriggerClientEvent('inventory:client:UseAmmo', source)
+    end)
+end
+


### PR DESCRIPTION
## Summary
- register ammo items to trigger ReloadWeapon when used
- support qb, ps, and ox inventory when checking and removing ammo
- document reloading via ammo items while retaining R key control

## Testing
- `luac -p qb-weapons/server/main.lua Browns-QBWeaponReload/code/server.lua`
- `luac -p qb-weapons/server/main.lua Browns-QBWeaponReload/code/client.lua Browns-QBWeaponReload/code/server.lua` *(fails: unexpected symbol near ``WEAPON_UNARMED``)*


------
https://chatgpt.com/codex/tasks/task_e_68b01bd891dc832681c47ad2010114cb