### PR TITLE
feat: add inventory bridge

### DIFF
--- a/Browns-QBWeaponReload/README.md
+++ b/Browns-QBWeaponReload/README.md
@@ -1,5 +1,5 @@
 # Browns QB Reload Weapons by Brown Development
-# NOW WORKS WITH qb, ps, & lj inventory!!!
+# Now works with qb, lj, ps, and ox inventory through a configurable bridge!
 # Preview Video: https://youtu.be/TLSnJvRJPEI
 
 
@@ -43,3 +43,11 @@ end
 ```
 
 Using an ammo item now calls the exported `ReloadWeapon` function. Players can still press **R** thanks to the key mapping in `client.lua`.
+
+## Inventory Configuration
+
+Set your inventory system in `config.lua` to one of the supported values: `qb-inventory`, `lj-inventory`, `ps-inventory`, or `ox_inventory`. The script automatically selects the correct adapter through the new inventory bridge.
+
+## Manual Testing
+
+Manual reload test cases for each supported inventory are available in [TESTING.md](TESTING.md).

--- a/Browns-QBWeaponReload/TESTING.md
+++ b/Browns-QBWeaponReload/TESTING.md
@@ -1,0 +1,25 @@
+# Manual Reload Testing
+
+The following cases verify weapon reloading using each supported inventory system.
+
+## qb-inventory
+1. Set `config.inventory` to `qb-inventory`.
+2. Give a player an ammo item (e.g. `pistol_ammo`).
+3. Fire a few rounds and press **R**.
+4. Confirm that ammo is added to the weapon and the item count decreases.
+
+## lj-inventory
+1. Set `config.inventory` to `lj-inventory`.
+2. Provide the appropriate ammo item.
+3. Reload the weapon with **R** or the `ReloadWeapon` export.
+4. Ensure the ammo item is removed and the weapon ammo increases.
+
+## ps-inventory
+1. Set `config.inventory` to `ps-inventory`.
+2. Give a player an ammo item.
+3. Reload and verify ammo usage mirrors inventory counts.
+
+## ox_inventory
+1. Set `config.inventory` to `ox_inventory`.
+2. Grant the player ammo and attempt a reload.
+3. Check that `ox_inventory` shows the item count reduced by the reloaded amount.

--- a/Browns-QBWeaponReload/code/inventory_bridge.lua
+++ b/Browns-QBWeaponReload/code/inventory_bridge.lua
@@ -1,0 +1,97 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
+local adapters = {}
+
+adapters['qb-inventory'] = {
+    HasItem = function(src, item, amount)
+        local Player = QBCore.Functions.GetPlayer(src)
+        if not Player then return false end
+        local data = Player.Functions.GetItemByName(item)
+        if not data then return false end
+        return data.amount >= (amount or 1)
+    end,
+    GetItemAmount = function(src, item)
+        local Player = QBCore.Functions.GetPlayer(src)
+        local data = Player and Player.Functions.GetItemByName(item)
+        return data and data.amount or nil
+    end,
+    RemoveItem = function(src, item, amount)
+        local Player = QBCore.Functions.GetPlayer(src)
+        local data = Player and Player.Functions.GetItemByName(item)
+        if data and data.amount >= amount then
+            Player.Functions.RemoveItem(item, amount)
+            return true
+        end
+        return false
+    end
+}
+
+adapters['lj-inventory'] = {
+    HasItem = function(src, item, amount)
+        local data = exports['lj-inventory']:GetItemByName(src, item)
+        return data and data.amount >= (amount or 1)
+    end,
+    GetItemAmount = function(src, item)
+        local data = exports['lj-inventory']:GetItemByName(src, item)
+        return data and data.amount or nil
+    end,
+    RemoveItem = function(src, item, amount)
+        local data = exports['lj-inventory']:GetItemByName(src, item)
+        if data and data.amount >= amount then
+            exports['lj-inventory']:RemoveItem(src, item, amount)
+            return true
+        end
+        return false
+    end
+}
+
+adapters['ps-inventory'] = {
+    HasItem = function(src, item, amount)
+        local data = exports['ps-inventory']:GetItemByName(src, item)
+        return data and data.amount >= (amount or 1)
+    end,
+    GetItemAmount = function(src, item)
+        local data = exports['ps-inventory']:GetItemByName(src, item)
+        return data and data.amount or nil
+    end,
+    RemoveItem = function(src, item, amount)
+        local data = exports['ps-inventory']:GetItemByName(src, item)
+        if data and data.amount >= amount then
+            exports['ps-inventory']:RemoveItem(src, item, amount)
+            return true
+        end
+        return false
+    end
+}
+
+adapters['ox_inventory'] = {
+    HasItem = function(src, item, amount)
+        local count = exports.ox_inventory:Search(src, 'count', item)
+        return count >= (amount or 1)
+    end,
+    GetItemAmount = function(src, item)
+        local count = exports.ox_inventory:Search(src, 'count', item)
+        return count > 0 and count or nil
+    end,
+    RemoveItem = function(src, item, amount)
+        return exports.ox_inventory:RemoveItem(src, item, amount) > 0
+    end
+}
+
+local adapter = adapters[config.inventory] or adapters['qb-inventory']
+
+local InventoryBridge = {}
+
+function InventoryBridge.HasItem(src, item, amount)
+    return adapter.HasItem(src, item, amount)
+end
+
+function InventoryBridge.GetItemAmount(src, item)
+    return adapter.GetItemAmount(src, item)
+end
+
+function InventoryBridge.RemoveItem(src, item, amount)
+    return adapter.RemoveItem(src, item, amount)
+end
+
+return InventoryBridge

--- a/Browns-QBWeaponReload/code/server.lua
+++ b/Browns-QBWeaponReload/code/server.lua
@@ -1,8 +1,8 @@
 local QBCore = exports['qb-core']:GetCoreObject()
+local Inventory = require 'code.inventory_bridge'
 
 QBCore.Functions.CreateCallback('browns_reload:GetAmount', function(source, cb, types) -- Passing the amount of ammo the player has to the client
-    local src = source 
-    local Player = QBCore.Functions.GetPlayer(src)
+    local src = source
     local ammo_type
     local ammo_amounts
     if types == 'AMMO_PISTOL' then 
@@ -22,16 +22,7 @@ QBCore.Functions.CreateCallback('browns_reload:GetAmount', function(source, cb, 
     end
 
     if ammo_type then
-        if config.inventory == 'ox_inventory' then
-            ammo_amounts = exports.ox_inventory:Search(src, 'count', ammo_type)
-            if ammo_amounts <= 0 then ammo_amounts = nil end
-        elseif config.inventory == 'ps-inventory' then
-            local item = exports['ps-inventory']:GetItemByName(src, ammo_type)
-            ammo_amounts = item and item.amount or nil
-        else -- qb-inventory and similar
-            local item = Player and Player.Functions.GetItemByName(ammo_type)
-            ammo_amounts = item and item.amount or nil
-        end
+        ammo_amounts = Inventory.GetItemAmount(src, ammo_type)
     end
 
     cb(ammo_amounts, ammo_type)
@@ -40,19 +31,5 @@ end)
 RegisterNetEvent('browns_reload:RemoveAmmoItem', function(ammo, counts) -- Removing reloaded ammo items from the player
     local src = source
     counts = tonumber(counts)
-    local Player = QBCore.Functions.GetPlayer(src)
-
-    if config.inventory == 'ox_inventory' then
-        exports.ox_inventory:RemoveItem(src, ammo, counts)
-    elseif config.inventory == 'ps-inventory' then
-        local item = exports['ps-inventory']:GetItemByName(src, ammo)
-        if item and item.amount >= counts then
-            exports['ps-inventory']:RemoveItem(src, ammo, counts)
-        end
-    else
-        local item = Player and Player.Functions.GetItemByName(ammo)
-        if item and item.amount >= counts then
-            Player.Functions.RemoveItem(ammo, counts)
-        end
-    end
+    Inventory.RemoveItem(src, ammo, counts)
 end)

--- a/Browns-QBWeaponReload/config.lua
+++ b/Browns-QBWeaponReload/config.lua
@@ -2,6 +2,7 @@ config = {}
 
 -- accepted inventories: --
 -- 'qb-inventory'
+-- 'lj-inventory'
 -- 'ps-inventory'
 -- 'ox_inventory'
 

--- a/Browns-QBWeaponReload/fxmanifest.lua
+++ b/Browns-QBWeaponReload/fxmanifest.lua
@@ -6,6 +6,7 @@ client_scripts {
     'code/client.lua'
 }
 server_scripts {
+    'code/inventory_bridge.lua',
     'code/server.lua'
 }
 shared_scripts {


### PR DESCRIPTION
## Summary
- add inventory bridge module supporting qb, lj, ps and ox inventory
- use bridge in server logic
- document manual testing for all supported inventories

## Testing
- `luacheck Browns-QBWeaponReload/code/*.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b01d368a108326ab3c2142d9fb2658