### PR TITLE
Delegate crafting to RaySist-Crafting

### DIFF
--- a/qb-jobcreator/README.md
+++ b/qb-jobcreator/README.md
@@ -33,3 +33,13 @@ Config.CraftingRecipes = {
 ```
 
 En la tienda del herrero añade `metal_ore` con el precio y stock deseado.  Los trabajadores comprarán el mineral, lo refinarán mediante la receta anterior y luego podrán vender las `metal_bar` o utilizarlas en otras recetas.
+
+## Integración con RaySist-Crafting
+
+Este recurso delega el sistema de crafteo en **RaySist-Crafting**, por lo que dicho recurso debe estar instalado y en ejecución.
+
+- Las recetas y categorías de crafteo se almacenan en la base de datos del recurso externo.
+- Configura las recetas y categorías necesarias antes de utilizar las mesas de crafteo creadas con `qb-jobcreator`.
+- RaySist-Crafting gestiona el inventario, las habilidades y los planos requeridos para cada receta.
+
+Sin esta dependencia las zonas de tipo `crafting` no funcionarán correctamente.

--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -185,6 +185,24 @@ local function openCraftMenu(z)
   TriggerEvent('RaySist-Crafting:client:OpenCrafting', { tableName = z.data.name })
 end
 
+-- Puente para delegar el crafteo en RaySist-Crafting
+RegisterNetEvent('RaySist-Crafting:client:CraftItem', function(recipe)
+  TriggerServerEvent('RaySist-Crafting:server:CraftItem', recipe)
+end)
+
+-- Eventos de progreso y resultado proporcionados por RaySist-Crafting
+RegisterNetEvent('RaySist-Crafting:client:CraftingProgress', function(_, time)
+  Progress('Crafteando...', (time or 0) * 1000)
+end)
+
+RegisterNetEvent('RaySist-Crafting:client:CraftingResult', function(success)
+  if success then
+    QBCore.Functions.Notify('Crafteo completado.', 'success')
+  else
+    QBCore.Functions.Notify('Crafteo fallido.', 'error')
+  end
+end)
+
 -- =====================================
 -- Targets por zona
 -- =====================================

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -798,50 +798,15 @@ end)
 
 RegisterNetEvent('qb-jobcreator:server:craft', function(zoneId, recipeKey)
   local src = source
-  local ok, zone, Player = playerInJobZone(src, findZoneById(zoneId), 'crafting')
+  local ok, zone = playerInJobZone(src, findZoneById(zoneId), 'crafting')
   if not ok then return end
   local rname = recipeKey or (zone.data and zone.data.recipe)
-  local recipe = Config.CraftingRecipes and Config.CraftingRecipes[rname]
-  if not recipe then
+  if not rname then
     TriggerClientEvent('QBCore:Notify', src, 'Receta no válida', 'error')
     return
   end
-  for _, req in ipairs(recipe.inputs or {}) do
-    local need = req.amount or req.qty or 1
-    local have = 0
-    if Config.Integrations.UseQbInventory then
-      local it = Player.Functions.GetItemByName(req.item)
-      have = (it and it.amount) or 0
-    else
-      have = exports.ox_inventory:Search(src, 'count', req.item) or 0
-    end
-    if have < need then
-      TriggerClientEvent('QBCore:Notify', src, 'Faltan materiales', 'error')
-      return
-    end
-  end
-  TriggerClientEvent('qb-jobcreator:client:craftProgress', src, recipe.time or 3000)
-  SetTimeout(recipe.time or 3000, function()
-    local P = QBCore.Functions.GetPlayer(src)
-    if not P then return end
-    for _, req in ipairs(recipe.inputs or {}) do
-      local qty = req.amount or req.qty or 1
-      if Config.Integrations.UseQbInventory then
-        P.Functions.RemoveItem(req.item, qty)
-      else
-        exports.ox_inventory:RemoveItem(src, req.item, qty)
-      end
-    end
-    local out = recipe.output or {}
-    if out.item then
-      local q = out.amount or out.qty or 1
-      if Config.Integrations.UseQbInventory then
-        P.Functions.AddItem(out.item, q)
-      else
-        exports.ox_inventory:AddItem(src, out.item, q)
-      end
-    end
-  end)
+  -- Delegar el proceso de crafteo al recurso RaySist-Crafting
+  TriggerClientEvent('RaySist-Crafting:client:CraftItem', src, rname)
 end)
 
 RegisterNetEvent('qb-jobcreator:server:collect', function(zoneId)


### PR DESCRIPTION
## Summary
- forward jobcreator craft requests to RaySist-Crafting
- hook client zones to RaySist-Crafting progress and result events
- document external RaySist-Crafting dependency and database recipe setup

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b024e422f883269ca4e5d14c0a0c27