### PR TITLE
feat(jobcreator): notify job zone restrictions

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -739,10 +739,16 @@ local function playerInJobZone(src, zone, ztype)
   if not Player or not Player.PlayerData then return false end
   local jd = Player.PlayerData.job or {}
   local cid = Player.PlayerData.citizenid
-  if jd.name ~= zone.job and not Multi_Has(cid, zone.job) then return false end
+  if jd.name ~= zone.job and not Multi_Has(cid, zone.job) then
+    TriggerClientEvent('QBCore:Notify', src, 'No tienes acceso a esta tienda.', 'error')
+    return false
+  end
   local coords = GetEntityCoords(GetPlayerPed(src))
   local dist = #(coords - vector3(zone.coords.x, zone.coords.y, zone.coords.z))
-  if dist > (zone.radius or 2.0) + 0.1 then return false end
+  if dist > (zone.radius or 2.0) + 0.1 then
+    TriggerClientEvent('QBCore:Notify', src, 'Acércate más a la zona para abrir la tienda.', 'error')
+    return false
+  end
   return true, zone, Player
 end
 


### PR DESCRIPTION
## Summary
- notify player when entering shop without required job
- notify player when outside zone radius

## Testing
- `luac -p qb-jobcreator/server/main.lua` *(fails: command not found: luac)*
- `fxserver +exec server.cfg` *(fails: command not found: fxserver)*

------
https://chatgpt.com/codex/tasks/task_e_68b029f6ad808326989f215618868804