### PR TITLE
feat: export crafting functions

### DIFF
--- a/RaySist-Crafting/README.md
+++ b/RaySist-Crafting/README.md
@@ -4,8 +4,6 @@
 
 
 ![craft](https://i.ibb.co/KzXCBqfV/Craft-removebg.png)
-
->>>>>>> c6eee8b2f542c02f20c45a6ee5388a85ef07b4fc
 A modern crafting system for FiveM QBCore framework.
 
 ## Features
@@ -52,6 +50,20 @@ Players can interact with crafting tables using qb-target. The crafting menu all
 2. View required materials and crafting time
 3. Craft items if they have the required materials
 4. Track their crafting skill progress
+
+## Exports
+
+The resource exposes several server-side exports:
+
+- `GetCraftingData(jobName)` → table with `zones`, `categories` and `recipes` filtered for the job.
+- `CreateCategory(source, category)` → `id`
+- `RenameCategory(source, data)` → `bool`
+- `SaveRecipe(source, recipe)` → `bool`
+- `DeleteRecipe(source, name)` → `bool`
+- `AddZone(source, zone)` → `id`
+- `DeleteZone(source, id)` → `bool`
+
+Each function requires admin permissions on `source` when modifying data.
 
 ## Credits
 

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -27,10 +27,7 @@ local function SanitizeShopItems(items)
 end
 
 local function RayCraft_Add(src, zone)
-  local cb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:AddZone']
-  if not cb then return nil end
-  local rid
-  cb(src, function(_, id) rid = id end, {
+  return exports['RaySist-Crafting']:AddZone(src, {
     name = (zone.data and zone.data.name) or ('jc_'..zone.job..'_'..zone.id),
     model = (zone.data and zone.data.model) or 'gr_prop_gr_bench_04b',
     coords = { x = zone.coords.x, y = zone.coords.y, z = zone.coords.z, w = zone.coords.w or 0.0 },
@@ -39,12 +36,10 @@ local function RayCraft_Add(src, zone)
     requiredJob = zone.job,
     requiredItems = (zone.data and zone.data.requiredItems) or {}
   })
-  return rid
 end
 
 local function RayCraft_Delete(src, rid)
-  local cb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:DeleteZone']
-  if cb and rid then cb(src, function() end, rid) end
+  if rid then exports['RaySist-Crafting']:DeleteZone(src, rid) end
 end
 
 -- ===== Helpers =====
@@ -372,75 +367,46 @@ QBCore.Functions.CreateCallback('qb-jobcreator:server:getZones', function(src, c
 end)
 
 QBCore.Functions.CreateCallback('qb-jobcreator:server:getRecipes', function(src, cb)
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:GetCraftingData']
-  if not craftCb then return cb({}) end
-  craftCb(src, function(data)
-    cb((data and data.recipes) or {})
-  end)
+  local Player = QBCore.Functions.GetPlayer(src)
+  local job = Player and Player.PlayerData.job.name or nil
+  local data = exports['RaySist-Crafting']:GetCraftingData(job)
+  cb((data and data.recipes) or {})
 end)
 
 QBCore.Functions.CreateCallback('qb-jobcreator:server:getCategories', function(src, cb)
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:GetCraftingData']
-  if not craftCb then return cb({}) end
-  craftCb(src, function(data)
-    cb((data and data.categories) or {})
-  end)
+  local Player = QBCore.Functions.GetPlayer(src)
+  local job = Player and Player.PlayerData.job.name or nil
+  local data = exports['RaySist-Crafting']:GetCraftingData(job)
+  cb((data and data.categories) or {})
 end)
 
 local function SyncRay()
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:GetCraftingData']
-  if not craftCb then return end
-  craftCb(0, function(dat)
-    if dat then TriggerClientEvent('RaySist-Crafting:client:SyncData', -1, dat) end
-  end)
+  local dat = exports['RaySist-Crafting']:GetCraftingData(nil)
+  if dat then TriggerClientEvent('RaySist-Crafting:client:SyncData', -1, dat) end
 end
 
 RegisterNetEvent('qb-jobcreator:server:createCategory', function(cat)
   local src = source; if not ensurePerm(src) then return end
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:CreateCategory']
-  if not craftCb then
-    TriggerClientEvent('QBCore:Notify', src, 'Crafting callback not found', 'error')
-    return
-  end
-  craftCb(src, function()
-    SyncRay()
-  end, cat)
+  exports['RaySist-Crafting']:CreateCategory(src, cat)
+  SyncRay()
 end)
 
 RegisterNetEvent('qb-jobcreator:server:renameCategory', function(data)
   local src = source; if not ensurePerm(src) then return end
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:RenameCategory']
-  if not craftCb then
-    TriggerClientEvent('QBCore:Notify', src, 'Crafting callback not found', 'error')
-    return
-  end
-  craftCb(src, function()
-    SyncRay()
-  end, data)
+  exports['RaySist-Crafting']:RenameCategory(src, data)
+  SyncRay()
 end)
 
 RegisterNetEvent('qb-jobcreator:server:saveRecipe', function(recipe)
   local src = source; if not ensurePerm(src) then return end
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:SaveRecipe']
-  if not craftCb then
-    TriggerClientEvent('QBCore:Notify', src, 'Crafting callback not found', 'error')
-    return
-  end
-  craftCb(src, function()
-    SyncRay()
-  end, recipe)
+  exports['RaySist-Crafting']:SaveRecipe(src, recipe)
+  SyncRay()
 end)
 
 RegisterNetEvent('qb-jobcreator:server:deleteRecipe', function(name)
   local src = source; if not ensurePerm(src) then return end
-  local craftCb = QBCore.ServerCallbacks and QBCore.ServerCallbacks['RaySist-Crafting:server:DeleteRecipe']
-  if not craftCb then
-    TriggerClientEvent('QBCore:Notify', src, 'Crafting callback not found', 'error')
-    return
-  end
-  craftCb(src, function()
-    SyncRay()
-  end, name)
+  exports['RaySist-Crafting']:DeleteRecipe(src, name)
+  SyncRay()
 end)
 
 RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)


### PR DESCRIPTION
## Summary
- add exported helpers for zone, category and recipe management in RaySist-Crafting
- switch jobcreator integration to use the new exports
- document RaySist-Crafting server exports

## Testing
- `luac -p RaySist-Crafting/server/main.lua`
- `luac -p qb-jobcreator/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b0322b88088326944ee6f2a2f80d86