### PR TITLE
feat: activate ox inventory adapter

### DIFF
--- a/Browns-QBWeaponReload/config.lua
+++ b/Browns-QBWeaponReload/config.lua
@@ -6,4 +6,4 @@ config = {}
 -- 'ps-inventory'
 -- 'ox_inventory'
 
-config.inventory = 'qb-inventory' 
+config.inventory = 'ox_inventory' 


### PR DESCRIPTION
## Summary
- default inventory to `ox_inventory` for Browns-QBWeaponReload

## Testing
- `lua - <<'EOF'
config = {}
dofile('Browns-QBWeaponReload/config.lua')
exports = {
  ['qb-core'] = {GetCoreObject = function(self) return {} end},
  ox_inventory = {
      Search = function(self, src, mode, item) return 5 end,
      RemoveItem = function(self, src, item, amount) return 1 end
  }
}
local inventory_bridge = dofile('Browns-QBWeaponReload/code/inventory_bridge.lua')
print('HasItem', inventory_bridge.HasItem(1, 'pistol_ammo', 1))
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b036a59e5c832692f9eba1128f72e5