### PR TITLE
Refactor weapon reload to avoid weaponData dependence

### DIFF
--- a/Browns-QBWeaponReload/code/client.lua
+++ b/Browns-QBWeaponReload/code/client.lua
@@ -1,7 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject() -- Import QBCore
 
-local weaponData = nil -- Initially Define Weapon Data as "nothing" until weapon data is passed from the below Event Handler
-
 local no_return = { -- List of weapons that dont take ammo (Cant Be Reloaded)
     {weapon = 'weapon_stickybomb'},
     {weapon = 'weapon_pipebomb'},
@@ -16,61 +14,58 @@ local no_return = { -- List of weapons that dont take ammo (Cant Be Reloaded)
     {weapon = 'weapon_unarmed'}
 }
 
-RegisterNetEvent('qb-weapons:client:DrawWeapon') -- Add Event Handler to event that is triggered when player uses a weapon
-AddEventHandler('qb-weapons:client:DrawWeapon', function(data)
-    local weaponName = tostring(data.name)
-    for _, cant_reload in ipairs(no_return) do 
-        if weaponName == tostring(cant_reload.weapon) then 
-            weaponData = nil 
-            break 
-        else
-            weaponData = data -- Redefine weaponData with the data of the weapon if the weapon takes ammo
-        end
-    end
-end)
-
-function ReloadWeapon() -- Creating the reloading functionality  
+function ReloadWeapon() -- Creating the reloading functionality
     local ped = PlayerPedId()
-    if weaponData ~= nil and GetSelectedPedWeapon(ped) ~= `WEAPON_UNARMED` then 
-        local weapons = GetSelectedPedWeapon(ped)
-        local total = GetAmmoInPedWeapon(ped, weapons)
-        local maxAmmo = GetMaxAmmoInClip(ped, weapons, 1)
-        local sum = tonumber(maxAmmo) - tonumber(total)
-        if total < maxAmmo then
-            QBCore.Functions.TriggerCallback('browns_reload:GetAmount', function(count, item) -- Getting the Amount of ammo the player has from the server
-                if count ~= nil and item ~= nil then 
-                    sum = tonumber(sum)
-                    item = tostring(item)
-                    if count ~= nil and count ~= false then 
-                        count = tonumber(count)
-                        if count > 0 then 
-                            if count > sum then 
-                                local new_total = GetAmmoInPedWeapon(ped, weapons)
-                                SetAmmoInClip(ped, weapons, 0)
-                                AddAmmoToPed(ped, weapons, sum + new_total)
-                                TriggerServerEvent("qb-weapons:server:UpdateWeaponAmmo", weaponData, sum + new_total)
-                                TriggerServerEvent('browns_reload:RemoveAmmoItem', item, sum)
-                                if config.inventory == 'ox_inventory' then
-                                    -- ox_inventory handles item removal server-side; no ItemBox needed
+    local weapons = GetSelectedPedWeapon(ped)
+    if weapons ~= `WEAPON_UNARMED` then
+        local weaponInfo = QBCore.Shared.Weapons[weapons]
+        if weaponInfo then
+            local weaponName = tostring(weaponInfo.name)
+            for _, cant_reload in ipairs(no_return) do
+                if weaponName == tostring(cant_reload.weapon) then
+                    return
+                end
+            end
+
+            local total = GetAmmoInPedWeapon(ped, weapons)
+            local maxAmmo = GetMaxAmmoInClip(ped, weapons, 1)
+            local sum = tonumber(maxAmmo) - tonumber(total)
+            if total < maxAmmo then
+                QBCore.Functions.TriggerCallback('browns_reload:GetAmount', function(count, item) -- Getting the Amount of ammo the player has from the server
+                    if count ~= nil and item ~= nil then
+                        sum = tonumber(sum)
+                        item = tostring(item)
+                        if count ~= nil and count ~= false then
+                            count = tonumber(count)
+                            if count > 0 then
+                                if count > sum then
+                                    local new_total = GetAmmoInPedWeapon(ped, weapons)
+                                    SetAmmoInClip(ped, weapons, 0)
+                                    AddAmmoToPed(ped, weapons, sum + new_total)
+                                    TriggerServerEvent("qb-weapons:server:UpdateWeaponAmmo", weapons, sum + new_total)
+                                    TriggerServerEvent('browns_reload:RemoveAmmoItem', item, sum)
+                                    if config.inventory == 'ox_inventory' then
+                                        -- ox_inventory handles item removal server-side; no ItemBox needed
+                                    else
+                                        TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[item], "remove")
+                                    end
                                 else
-                                    TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[item], "remove")
-                                end
-                            else
-                                local new_total = GetAmmoInPedWeapon(ped, weapons)
-                                SetAmmoInClip(ped, weapons, 0)
-                                AddAmmoToPed(ped, weapons, count + new_total)
-                                TriggerServerEvent("qb-weapons:server:UpdateWeaponAmmo", weaponData, count + new_total)
-                                TriggerServerEvent('browns_reload:RemoveAmmoItem', item, count)
-                                if config.inventory == 'ox_inventory' then
-                                    -- ox_inventory handles item removal server-side; no ItemBox needed
-                                else
-                                    TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[item], "remove")
+                                    local new_total = GetAmmoInPedWeapon(ped, weapons)
+                                    SetAmmoInClip(ped, weapons, 0)
+                                    AddAmmoToPed(ped, weapons, count + new_total)
+                                    TriggerServerEvent("qb-weapons:server:UpdateWeaponAmmo", weapons, count + new_total)
+                                    TriggerServerEvent('browns_reload:RemoveAmmoItem', item, count)
+                                    if config.inventory == 'ox_inventory' then
+                                        -- ox_inventory handles item removal server-side; no ItemBox needed
+                                    else
+                                        TriggerEvent('qb-inventory:client:ItemBox', QBCore.Shared.Items[item], "remove")
+                                    end
                                 end
                             end
                         end
                     end
-                end
-            end, QBCore.Shared.Weapons[weapons]["ammotype"])
+                end, weaponInfo["ammotype"])
+            end
         end
     end
 end

--- a/Browns-QBWeaponReload/code/server.lua
+++ b/Browns-QBWeaponReload/code/server.lua
@@ -33,3 +33,27 @@ RegisterNetEvent('browns_reload:RemoveAmmoItem', function(ammo, counts) -- Remov
     counts = tonumber(counts)
     Inventory.RemoveItem(src, ammo, counts)
 end)
+
+-- Update weapon ammo using weapon hash sent from client
+RegisterNetEvent('qb-weapons:server:UpdateWeaponAmmo', function(weaponHash, ammo)
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if not Player then return end
+
+    local weaponInfo = QBCore.Shared.Weapons[weaponHash]
+    if not weaponInfo then return end
+
+    local weaponName = weaponInfo.name
+    local weaponItem = Player.Functions.GetItemByName(weaponName)
+    if not weaponItem then return end
+
+    weaponItem.info = weaponItem.info or {}
+    weaponItem.info.ammo = ammo
+
+    if config.inventory == 'ox_inventory' then
+        exports.ox_inventory:SetMetadata(src, weaponItem.slot, weaponItem.info)
+    else
+        Player.Functions.RemoveItem(weaponName, 1, weaponItem.slot)
+        Player.Functions.AddItem(weaponName, 1, weaponItem.slot, weaponItem.info)
+    end
+end)


### PR DESCRIPTION
## Summary
- derive reload info from current weapon instead of cached `weaponData`
- update ammo metadata server-side using weapon hash

## Testing
- `luac -p Browns-QBWeaponReload/code/client.lua` *(fails: unexpected symbol near '`')*
- `luac -p Browns-QBWeaponReload/code/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b0380965f48326864892be98b3c90e