### PR TITLE
Remove duplicate reload key mapping

### DIFF
--- a/Browns-QBWeaponReload/code/client.lua
+++ b/Browns-QBWeaponReload/code/client.lua
@@ -80,4 +80,3 @@ end)
 
 exports('ReloadWeapon', ReloadWeapon) -- export to use reload function in other scripts
 
-RegisterKeyMapping('browns_reload', 'reload your weapon', 'keyboard', 'R')  -- Registering the 'R' key as the button to do reload functionality


### PR DESCRIPTION
## Summary
- remove Browns-QBWeaponReload key mapping to avoid conflicting reload keys

## Testing
- `luac -p Browns-QBWeaponReload/code/client.lua` *(fails: unexpected symbol near '`')*
- `rg "RegisterKeyMapping" -n`


------
https://chatgpt.com/codex/tasks/task_e_68b06f5326708326954220062c91e6c2