### PR TITLE
feat: handle missing inventory

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -69,14 +69,17 @@ end)
 -- Abre una tienda registrada en qb-inventory u ox_inventory
 RegisterNetEvent('qb-jobcreator:client:openInvShop', function(id, useServerEvent)
   local oxStarted = GetResourceState('ox_inventory') == 'started'
+  local qbStarted = GetResourceState('qb-inventory') == 'started'
   if oxStarted then
     exports.ox_inventory:openInventory('shop', id)
-  else
+  elseif qbStarted then
     if useServerEvent then
       TriggerServerEvent('qb-inventory:server:OpenShop', id)
     else
       TriggerEvent('qb-inventory:client:OpenShop', id)
     end
+  else
+    TriggerEvent('QBCore:Notify', 'No hay inventario disponible.', 'error')
   end
 end)
 


### PR DESCRIPTION
## Summary
- ensure inventory shop opener verifies both ox_inventory and qb-inventory
- validate stash and shop serverside to notify when no inventory system exists

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b0d913e6c883268ab3630fab0aa2d9