### PR TITLE
Remove resource stopping for qb weapons and shops

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -25,13 +25,6 @@ AddEventHandler('QBCore:Server:OnGangUpdate', function(source, gang)
     inventory.player.groups[gang.name] = gang.grade.level
 end)
 
---[[
-AddEventHandler('onResourceStart', function(resource)
-    if resource ~= 'qb-weapons' and resource ~= 'qb-shops' then return end
-    StopResource(resource)
-end)
-]]
-
 ---@param item SlotWithItem?
 ---@return SlotWithItem?
 local function setItemCompatibilityProps(item)
@@ -93,17 +86,6 @@ AddEventHandler('QBCore:Server:PlayerLoaded', setupPlayer)
 SetTimeout(500, function()
     QBCore = exports['qb-core']:GetCoreObject()
     server.GetPlayerFromId = QBCore.Functions.GetPlayer
-    local weapState = GetResourceState('qb-weapons')
-
-    if weapState ~= 'missing' and (weapState == 'started' or weapState == 'starting') then
-        StopResource('qb-weapons')
-    end
-
-    local shopState = GetResourceState('qb-shops')
-
-    if shopState ~= 'missing' and (shopState == 'started' or shopState == 'starting') then
-        StopResource('qb-shops')
-    end
 
     for _, Player in pairs(QBCore.Functions.GetQBPlayers()) do setupPlayer(Player) end
 end)


### PR DESCRIPTION
## Summary
- Prevent ox_inventory from stopping `qb-weapons` and `qb-shops` so they can remain active

## Testing
- `fxserver +set onesync on +exec server.cfg` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e0fb52708326bc0046632cc098fa