### PR TITLE
Register qb-inventory ItemBox and CheckWeapon events

### DIFF
--- a/ox_inventory/modules/bridge/qb/client.lua
+++ b/ox_inventory/modules/bridge/qb/client.lua
@@ -111,6 +111,11 @@ local function ItemBox(items, type, amount)
 end
 export('qb-inventory.ItemBox', ItemBox)
 
+RegisterNetEvent('qb-inventory:client:ItemBox', ItemBox)
+RegisterNetEvent('qb-inventory:client:CheckWeapon', function(weapon)
+    TriggerEvent('qb-weapons:client:CheckWeapon', weapon)
+end)
+
 export('qb-inventory.ShowHotbar', function()
     SendNUIMessage({ action = 'toggleHotbar', state = true })
 end)


### PR DESCRIPTION
## Summary
- Bridge qb-inventory client events for ItemBox and CheckWeapon in ox_inventory

## Testing
- `lua - <<'EOF'
function TriggerEvent(name, ...)
    print('TriggerEvent', name, ...)
end
function ItemBox(items, type, amount)
    print('ItemBox called', items, type, amount)
end
function RegisterNetEvent(name, fn)
    print('RegisterNetEvent', name)
    if fn then
        if name == 'qb-inventory:client:ItemBox' then
            fn({ name = 'bread' }, 'add', 1)
        elseif name == 'qb-inventory:client:CheckWeapon' then
            fn('weapon_pistol')
        end
    end
end

RegisterNetEvent('qb-inventory:client:ItemBox', ItemBox)
RegisterNetEvent('qb-inventory:client:CheckWeapon', function(weapon)
    TriggerEvent('qb-weapons:client:CheckWeapon', weapon)
end)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b0e73ae3f48326b7d3cea15880889c