### PR TITLE
feat: handle snowball inventory events

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -641,6 +641,14 @@ RegisterNetEvent('qb-inventory:server:BuyItem', function(shopId, itemName, price
     TriggerClientEvent('QBCore:Notify', src, ('Compraste %s x%s'):format(itemName, count), 'success')
 end)
 
+RegisterNetEvent('qb-inventory:server:snowball', function(action)
+    if action == 'add' then
+        Inventory.AddItem(source, 'weapon_snowball', 1)
+    elseif action == 'remove' then
+        Inventory.RemoveItem(source, 'weapon_snowball', 1)
+    end
+end)
+
 -- update item metadata
 export('qb-inventory.SetMetadata', function(source, name, metadata, amount, slot)
     if not name then return false end


### PR DESCRIPTION
## Summary
- add qb-inventory snowball event using ox_inventory bridge

## Testing
- ⚠️ `luac -p ox_inventory/modules/bridge/qb/server.lua` *(fails: syntax error near '+')*

------
https://chatgpt.com/codex/tasks/task_e_68b0e92c580c832689626742ed6e59c6