### PR TITLE
Use inventory exports for weapon data

### DIFF
--- a/ox_inventory/modules/bridge/qb/server.lua
+++ b/ox_inventory/modules/bridge/qb/server.lua
@@ -303,6 +303,12 @@ export('qb-inventory.SetItemData', function(invId, itemName, key, value, slot)
     elseif key == 'durability' or key == 'quality' then
         Inventory.SetDurability(invId, slotId, value)
         return true
+    elseif key == 'ammo' then
+        local slotItem = Inventory.GetSlot(invId, slotId)
+        local metadata = slotItem and slotItem.metadata or {}
+        metadata.ammo = value
+        Inventory.SetMetadata(invId, slotId, metadata)
+        return true
     end
 
     error(("qb-inventory.SetItemData no es compatible con la clave '%s'"):format(key))


### PR DESCRIPTION
## Summary
- replace weapon inventory updates with qb-inventory SetItemData calls
- stop mutating Player.PlayerData.items by using ox_inventory slot metadata
- add ammo support to qb-inventory SetItemData bridge

## Testing
- `luacheck qb-weapons/server/main.lua ox_inventory/modules/bridge/qb/server.lua` *(fails: command not found)*
- `apt-get install -y luacheck` *(fails: Unable to locate package luacheck)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ec370b60832685b715ddfc68a903