### PR TITLE
fix durability metadata for repaired weapons

### DIFF
--- a/qb-weapons/server/main.lua
+++ b/qb-weapons/server/main.lua
@@ -141,7 +141,8 @@ RegisterNetEvent('qb-weapons:server:TakeBackWeapon', function(k)
     local Player = QBCore.Functions.GetPlayer(src)
     if not Player then return end
     local itemdata = Config.WeaponRepairPoints[k].RepairingData.WeaponData
-    itemdata.info.quality = 100
+    itemdata.info.durability = itemdata.info.quality or 100
+    itemdata.info.quality = nil
     exports['qb-inventory']:AddItem(src, itemdata.name, 1, false, itemdata.info, 'qb-weapons:server:TakeBackWeapon')
     TriggerClientEvent('qb-inventory:client:ItemBox', src, QBCore.Shared.Items[itemdata.name], 'add')
     Config.WeaponRepairPoints[k].IsRepairing = false


### PR DESCRIPTION
## Summary
- convert quality metadata to durability before adding repaired weapons back to inventory

## Testing
- `luac -p qb-weapons/server/main.lua` *(fails: unexpected symbol near '`')*

------
https://chatgpt.com/codex/tasks/task_e_68b0eddf1668832681ab7a268bc66121