### PR TITLE
Configure ox_inventory for qb-target and disable weapon handling

### DIFF
--- a/ox_inventory/ox.cfg
+++ b/ox_inventory/ox.cfg
@@ -21,24 +21,25 @@ setr ox:locale "es"
 ##################
 ### OX TARGET ###
 ##################
+# Using qb-target; ox_target settings disabled
 
 # Toggle targeting when pressing the hotkey, instead of holding it down.
-setr ox_target:toggleHotkey 0
+# setr ox_target:toggleHotkey 0
 
 # Change the key to enable targeting (https://docs.fivem.net/docs/game-references/input-mapper-parameter-ids/keyboard)
-setr ox_target:defaultHotkey LMENU
+# setr ox_target:defaultHotkey LMENU
 
 # Draw a sprite (circle) at the centroid of a zone.
-setr ox_target:drawSprite 1
+# setr ox_target:drawSprite 1
 
 # Enable built-in targeting options, e.g. toggling vehicle doors.
-setr ox_target:defaults 1
+# setr ox_target:defaults 1
 
 # Enable debugging / testing options, entity outlines, and a raycast indicator.
-setr ox_target:debug 0
+# setr ox_target:debug 0
 
 # Enable / Disable leftclick to select options
-setr ox_target:leftClick 1
+# setr ox_target:leftClick 1
 
 ####################
 ### OX INVENTORY ###
@@ -56,7 +57,7 @@ setr inventory:slots 50
 setr inventory:weight 85000
 
 # Integrated support for ox_target stashes, shops, etc
-setr inventory:target true
+setr inventory:target false
 
 # Jobs with access to police armoury, evidence lockers, etc
 setr inventory:police ["police", "bcso", "sasp"]
@@ -101,6 +102,9 @@ setr inventory:dropmodel "prop_med_bag_01b"
 
 # Disarm the player if an unexpected weapon is in use (i.e. did not use the weapon item)
 setr inventory:weaponmismatch true
+
+# Disable ox_inventory weapon handling
+setr inventory:disableweapons 1
 
 # Ignore weapon mismatch checks for the given weapon type (e.g. ['WEAPON_SHOVEL', 'WEAPON_HANDCUFFS'])
 setr inventory:ignoreweapons []


### PR DESCRIPTION
## Summary
- disable ox_inventory weapon handling in ox.cfg
- turn off ox_target integration for qb-target compatibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ef17f46c8326b246dbffac6c31f1