### PR TITLE
fix: require inventory bridge module

### DIFF
--- a/Browns-QBWeaponReload/code/server.lua
+++ b/Browns-QBWeaponReload/code/server.lua
@@ -1,5 +1,5 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-local Inventory = require 'code.inventory_bridge'
+local Inventory = require('code.inventory_bridge')
 
 -- Ammo type to item mapping
 local AmmoTypes = {

--- a/Browns-QBWeaponReload/fxmanifest.lua
+++ b/Browns-QBWeaponReload/fxmanifest.lua
@@ -1,4 +1,5 @@
 fx_version 'bodacious'
+lua54 'yes'
 author 'Brown Development'
 description 'QB Reload Weapon'
 game 'gta5'
@@ -6,7 +7,6 @@ client_scripts {
     'code/client.lua'
 }
 server_scripts {
-    'code/inventory_bridge.lua',
     'code/server.lua'
 }
 shared_scripts {


### PR DESCRIPTION
## Summary
- enable Lua 5.4 for QBWeaponReload
- load inventory bridge via require and remove manifest entry

## Testing
- `luac -p code/server.lua code/inventory_bridge.lua`
- ⚠️ `lua -e "require('code.inventory_bridge')"` (fails: attempt to index a nil value 'exports' because FiveM exports aren't available)


------
https://chatgpt.com/codex/tasks/task_e_68b1002fc5888326b9d2e293f264a2a7