### PR TITLE
chore: set hotbar key to TAB

### DIFF
--- a/ox_inventory/ox.cfg
+++ b/ox_inventory/ox.cfg
@@ -74,7 +74,7 @@ setr inventory:autoreload false
 setr inventory:screenblur true
 
 # Default hotkeys to access primary and secondary inventories, and hotbar
-setr inventory:keys ["TAB", "K", "F1"]
+setr inventory:keys ["F2", "K", "TAB"]
 
 # Enable control action when inventory is open
 setr inventory:enablekeys [249]


### PR DESCRIPTION
## Summary
- set `inventory:keys` to use TAB for the hotbar

## Testing
- `fxserver restart ox_inventory` *(fails: command not found)*
- `npm test` *(fails: no such file or directory: package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1087948bc83269a6c644088b01dc2