### PR TITLE
feat: include inventory bridge and config order

### DIFF
--- a/Browns-QBWeaponReload/fxmanifest.lua
+++ b/Browns-QBWeaponReload/fxmanifest.lua
@@ -4,13 +4,14 @@ author 'Brown Development'
 description 'QB Reload Weapon'
 game 'gta5'
 client_scripts {
+    'config.lua',
     'code/client.lua'
 }
+
 server_scripts {
+    'config.lua',
+    'code/inventory_bridge.lua',
     'code/server.lua'
-}
-shared_scripts {
-    'config.lua'
 }
 dependencies {
     'qb-weapons'


### PR DESCRIPTION
## Summary
- ensure `config.lua` loads on both client and server before the bridge
- include `code/inventory_bridge.lua` so server can access inventory adapters

## Testing
- `luac -p fxmanifest.lua code/inventory_bridge.lua code/server.lua code/client.lua config.lua` *(fails: code/client.lua:20: unexpected symbol near '`')*


------
https://chatgpt.com/codex/tasks/task_e_68b121ca6d4483269e61594e60110544