### PR TITLE
feat: update crafting zone parameters

### DIFF
--- a/RaySist-Crafting/server/main.lua
+++ b/RaySist-Crafting/server/main.lua
@@ -26,14 +26,17 @@ end
 
 local function AddZoneFn(src, zone)
     if not QBCore.Functions.HasPermission(src, 'admin') then return nil end
-    local id = MySQL.insert.await('INSERT INTO crafting_zones (name, model, coords, distance, allowed_categories, required_job, required_items) VALUES (?, ?, ?, ?, ?, ?, ?)', {
+    local id = MySQL.insert.await('INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, spawn_object, model) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
         zone.name,
-        zone.model,
         json.encode(zone.coords),
         zone.distance or 2.5,
         json.encode(zone.allowedCategories or {}),
         zone.requiredJob,
-        json.encode(zone.requiredItems or {})
+        json.encode(zone.requiredItems or {}),
+        zone.useZone and 1 or 0,
+        zone.radius or 0.0,
+        zone.spawnObject == false and 0 or 1,
+        zone.model
     })
     if not id then return nil end
     zone.id = id
@@ -172,6 +175,9 @@ local function LoadCraftingData()
         z.coords = json.decode(z.coords or '{}')
         z.allowedCategories = json.decode(z.allowed_categories or '[]')
         z.requiredItems = json.decode(z.required_items or '[]')
+        z.useZone = z.use_zone == 1
+        z.radius = z.radius or 0.0
+        z.spawnObject = z.spawn_object == 1
     end
 
     for _, r in pairs(recipes) do

--- a/RaySist-Crafting/sql/crafting.sql
+++ b/RaySist-Crafting/sql/crafting.sql
@@ -20,12 +20,15 @@ CREATE TABLE IF NOT EXISTS crafting_recipes (
 CREATE TABLE IF NOT EXISTS crafting_zones (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(50) UNIQUE,
-    model VARCHAR(100) NOT NULL,
     coords LONGTEXT NOT NULL,
     distance FLOAT DEFAULT 2.5,
     allowed_categories LONGTEXT,
     required_job VARCHAR(50) DEFAULT NULL,
-    required_items LONGTEXT DEFAULT NULL
+    required_items LONGTEXT DEFAULT NULL,
+    use_zone TINYINT(1) DEFAULT 0,
+    radius FLOAT DEFAULT 0.0,
+    spawn_object TINYINT(1) DEFAULT 1,
+    model VARCHAR(100) DEFAULT NULL
 );
 
 -- Initial categories
@@ -46,9 +49,9 @@ INSERT INTO crafting_recipes (name, label, category, time, ingredients, require_
     ('lockpick','Lockpick','illegal',20,'[{"item":"metalscrap","amount":5,"label":"Metal Scrap"},{"item":"plastic","amount":5,"label":"Plastic"}]',0,NULL,NULL);
 
 -- Initial crafting zones
-INSERT INTO crafting_zones (name, model, coords, distance, allowed_categories, required_job) VALUES
-    ('police_table','gr_prop_gr_bench_04b','{"x":-968.11,"y":-3011.98,"z":13.95,"w":56.95}',2.5,'["police_weapons","ammo"]','police'),
-    ('ems_table','prop_tool_bench01','{"x":-963.64,"y":-3004.74,"z":13.95,"w":62.79}',2.5,'["ems"]','ambulance'),
-    ('restaurant_table','prop_cooker_03','{"x":-966.02,"y":-3008.91,"z":13.95,"w":63.94}',2.5,'["restaurant"]','burgershot'),
-    ('bar_table','prop_bar_fridge_01','{"x":-960.0,"y":-3000.0,"z":13.95,"w":0.0}',2.5,'["bar"]','bartender'),
-    ('illegal_table','prop_tool_bench02','{"x":-955.0,"y":-2995.0,"z":13.95,"w":0.0}',2.5,'["illegal"]','criminal');
+INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, spawn_object, model) VALUES
+    ('police_table','{"x":-968.11,"y":-3011.98,"z":13.95,"w":56.95}',2.5,'["police_weapons","ammo"]','police',NULL,0,2.5,1,'gr_prop_gr_bench_04b'),
+    ('ems_table','{"x":-963.64,"y":-3004.74,"z":13.95,"w":62.79}',2.5,'["ems"]','ambulance',NULL,0,2.5,1,'prop_tool_bench01'),
+    ('restaurant_table','{"x":-966.02,"y":-3008.91,"z":13.95,"w":63.94}',2.5,'["restaurant"]','burgershot',NULL,0,2.5,1,'prop_cooker_03'),
+    ('bar_table','{"x":-960.0,"y":-3000.0,"z":13.95,"w":0.0}',2.5,'["bar"]','bartender',NULL,0,2.5,1,'prop_bar_fridge_01'),
+    ('illegal_table','{"x":-955.0,"y":-2995.0,"z":13.95,"w":0.0}',2.5,'["illegal"]','criminal',NULL,0,2.5,1,'prop_tool_bench02');

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -28,12 +28,14 @@ end
 local function RayCraft_Add(src, zone)
   return exports['RaySist-Crafting']:AddZone(src, {
     name = (zone.data and zone.data.name) or ('jc_'..zone.job..'_'..zone.id),
-    model = (zone.data and zone.data.model) or 'gr_prop_gr_bench_04b',
     coords = { x = zone.coords.x, y = zone.coords.y, z = zone.coords.z, w = zone.coords.w or 0.0 },
     distance = zone.radius or 2.5,
     allowedCategories = (zone.data and zone.data.allowedCategories) or {},
     requiredJob = zone.job,
-    requiredItems = (zone.data and zone.data.requiredItems) or {}
+    requiredItems = (zone.data and zone.data.requiredItems) or {},
+    useZone = true,
+    radius = zone.radius,
+    spawnObject = false
   })
 end
 


### PR DESCRIPTION
## Summary
- configure RayCraft_Add to send zone radius and disable object spawning
- extend RaySist-Crafting AddZone to support zone-based fields without requiring a model
- update crafting SQL schema for new zone properties

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2014ad4e8832694b09db4190a9b5d