### PR TITLE
Persist optional crafting zone data

### DIFF
--- a/RaySist-Crafting/server/main.lua
+++ b/RaySist-Crafting/server/main.lua
@@ -26,7 +26,7 @@ end
 
 local function AddZoneFn(src, zone)
     if not QBCore.Functions.HasPermission(src, 'admin') then return nil end
-    local id = MySQL.insert.await('INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, spawn_object, model) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
+    local id = MySQL.insert.await('INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, min_z, max_z, length, width, heading, spawn_object, model) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
         zone.name,
         json.encode(zone.coords),
         zone.distance or 2.5,
@@ -34,7 +34,12 @@ local function AddZoneFn(src, zone)
         zone.requiredJob,
         json.encode(zone.requiredItems or {}),
         zone.useZone and 1 or 0,
-        zone.radius or 0.0,
+        zone.radius,
+        zone.minZ,
+        zone.maxZ,
+        zone.length,
+        zone.width,
+        zone.heading,
         zone.spawnObject == false and 0 or 1,
         zone.model
     })
@@ -176,7 +181,12 @@ local function LoadCraftingData()
         z.allowedCategories = json.decode(z.allowed_categories or '[]')
         z.requiredItems = json.decode(z.required_items or '[]')
         z.useZone = z.use_zone == 1
-        z.radius = z.radius or 0.0
+        z.radius = tonumber(z.radius)
+        z.minZ = tonumber(z.min_z)
+        z.maxZ = tonumber(z.max_z)
+        z.length = tonumber(z.length)
+        z.width = tonumber(z.width)
+        z.heading = tonumber(z.heading)
         z.spawnObject = z.spawn_object == 1
     end
 

--- a/RaySist-Crafting/sql/crafting.sql
+++ b/RaySist-Crafting/sql/crafting.sql
@@ -26,7 +26,12 @@ CREATE TABLE IF NOT EXISTS crafting_zones (
     required_job VARCHAR(50) DEFAULT NULL,
     required_items LONGTEXT DEFAULT NULL,
     use_zone TINYINT(1) DEFAULT 0,
-    radius FLOAT DEFAULT 0.0,
+    radius FLOAT DEFAULT NULL,
+    min_z FLOAT DEFAULT NULL,
+    max_z FLOAT DEFAULT NULL,
+    length FLOAT DEFAULT NULL,
+    width FLOAT DEFAULT NULL,
+    heading FLOAT DEFAULT NULL,
     spawn_object TINYINT(1) DEFAULT 1,
     model VARCHAR(100) DEFAULT NULL
 );
@@ -49,9 +54,9 @@ INSERT INTO crafting_recipes (name, label, category, time, ingredients, require_
     ('lockpick','Lockpick','illegal',20,'[{"item":"metalscrap","amount":5,"label":"Metal Scrap"},{"item":"plastic","amount":5,"label":"Plastic"}]',0,NULL,NULL);
 
 -- Initial crafting zones
-INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, spawn_object, model) VALUES
-    ('police_table','{"x":-968.11,"y":-3011.98,"z":13.95,"w":56.95}',2.5,'["police_weapons","ammo"]','police',NULL,0,2.5,1,'gr_prop_gr_bench_04b'),
-    ('ems_table','{"x":-963.64,"y":-3004.74,"z":13.95,"w":62.79}',2.5,'["ems"]','ambulance',NULL,0,2.5,1,'prop_tool_bench01'),
-    ('restaurant_table','{"x":-966.02,"y":-3008.91,"z":13.95,"w":63.94}',2.5,'["restaurant"]','burgershot',NULL,0,2.5,1,'prop_cooker_03'),
-    ('bar_table','{"x":-960.0,"y":-3000.0,"z":13.95,"w":0.0}',2.5,'["bar"]','bartender',NULL,0,2.5,1,'prop_bar_fridge_01'),
-    ('illegal_table','{"x":-955.0,"y":-2995.0,"z":13.95,"w":0.0}',2.5,'["illegal"]','criminal',NULL,0,2.5,1,'prop_tool_bench02');
+INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, min_z, max_z, length, width, heading, spawn_object, model) VALUES
+    ('police_table','{"x":-968.11,"y":-3011.98,"z":13.95,"w":56.95}',2.5,'["police_weapons","ammo"]','police',NULL,0,2.5,NULL,NULL,NULL,NULL,NULL,1,'gr_prop_gr_bench_04b'),
+    ('ems_table','{"x":-963.64,"y":-3004.74,"z":13.95,"w":62.79}',2.5,'["ems"]','ambulance',NULL,0,2.5,NULL,NULL,NULL,NULL,NULL,1,'prop_tool_bench01'),
+    ('restaurant_table','{"x":-966.02,"y":-3008.91,"z":13.95,"w":63.94}',2.5,'["restaurant"]','burgershot',NULL,0,2.5,NULL,NULL,NULL,NULL,NULL,1,'prop_cooker_03'),
+    ('bar_table','{"x":-960.0,"y":-3000.0,"z":13.95,"w":0.0}',2.5,'["bar"]','bartender',NULL,0,2.5,NULL,NULL,NULL,NULL,NULL,1,'prop_bar_fridge_01'),
+    ('illegal_table','{"x":-955.0,"y":-2995.0,"z":13.95,"w":0.0}',2.5,'["illegal"]','criminal',NULL,0,2.5,NULL,NULL,NULL,NULL,NULL,1,'prop_tool_bench02');


### PR DESCRIPTION
## Summary
- allow saving optional zone model and dimensions in `AddZoneFn`
- load and send radius/box data (`minZ`/`maxZ`, etc.) to clients
- extend `crafting_zones` table to store additional zone fields

## Testing
- `luac -p RaySist-Crafting/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2032e9be483269b6291da3e5075d1