### PR TITLE
fix: ensure craft menu uses valid name

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -181,8 +181,9 @@ local function GetClosestPlayerToMe(radius)
 end
 
 local function openCraftMenu(z)
-  if not z or not z.data or not z.data.name then return end
-  TriggerEvent('RaySist-Crafting:client:OpenCrafting', { tableName = z.data.name })
+  if not z or not ((z.data and z.data.name) or (z.job and z.id)) then return end
+  local name = (z.data and z.data.name) or ('jc_' .. z.job .. '_' .. z.id)
+  TriggerEvent('RaySist-Crafting:client:OpenCrafting', { tableName = name })
 end
 
 -- Puente para delegar el crafteo en RaySist-Crafting


### PR DESCRIPTION
## Summary
- ensure openCraftMenu uses zone name or generated fallback

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b204d253ec83268ef6fc33f340e88a