### PR TITLE
Fix nil zone name causing insert errors

### DIFF
--- a/RaySist-Crafting/server/main.lua
+++ b/RaySist-Crafting/server/main.lua
@@ -26,6 +26,7 @@ end
 
 local function AddZoneFn(src, zone)
     if not QBCore.Functions.HasPermission(src, 'admin') then return nil end
+    zone.name = zone.name or ('jc_%s_%d'):format(zone.requiredJob or 'job', os.time())
     local id = MySQL.insert.await('INSERT INTO crafting_zones (name, coords, distance, allowed_categories, required_job, required_items, use_zone, radius, min_z, max_z, length, width, heading, spawn_object, model) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', {
         zone.name,
         json.encode(zone.coords),


### PR DESCRIPTION
## Summary
- default zone names when absent to prevent SQL errors

## Testing
- `luac -p RaySist-Crafting/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b21e3a806883269f8b0464206a64df