### PR TITLE
feat: add crafting zone name column

### DIFF
--- a/RaySist-Crafting/server/main.lua
+++ b/RaySist-Crafting/server/main.lua
@@ -170,6 +170,10 @@ local function EnsureCraftingTables()
         local tableName = query:match('CREATE TABLE IF NOT EXISTS%s+`?(%w+)`?')
         print(('[RaySist-Crafting] Ensured table %s'):format(tableName or 'unknown'))
     end
+
+    MySQL.query.await(
+        [[ALTER TABLE crafting_zones ADD COLUMN IF NOT EXISTS name VARCHAR(50) UNIQUE]]
+    )
 end
 
 local function LoadCraftingData()


### PR DESCRIPTION
## Summary
- add missing `name` column to `crafting_zones` table

## Testing
- `luac -p RaySist-Crafting/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b21ef1feb88326a1a551d04b57aede