### PR TITLE
Integrate native crafting UI into job creator

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -194,3 +194,12 @@ end)
 RegisterNUICallback('getCraftingData', function(data, cb)
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(list) cb(list or {}) end, data and data.zoneId)
 end)
+
+RegisterNUICallback('craft', function(data, cb)
+  local zoneId = data and (data.zoneId or data.zone)
+  local recipe = data and data.recipe
+  if zoneId and recipe then
+    TriggerServerEvent('qb-jobcreator:server:craft', zoneId, recipe)
+  end
+  cb({ ok = true })
+end)

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -1009,7 +1009,7 @@ const CraftUI = (() => {
   let inventory = 'qb-inventory';
 
   function open(payload) {
-    zoneId = payload.zone;
+    zoneId = payload.zoneId || payload.zone;
     inventory = payload.inventory || 'qb-inventory';
     const recipes = payload.recipes || {};
     const wrap = document.getElementById('craft-list');
@@ -1049,7 +1049,7 @@ const CraftUI = (() => {
   document.addEventListener('click', (e) => {
     if (e.target.classList.contains('craft-btn')) {
       const recipe = e.target.dataset.recipe;
-      post('craft', { zone: zoneId, recipe });
+      post('craft', { zoneId: zoneId, recipe });
     }
   });
 


### PR DESCRIPTION
## Summary
- Replace RaySist crafting integration with native NUI crafting interface
- Add NUI callback for crafting requests and server event trigger
- Enhance web UI to open crafting panel and post craft actions

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b256d71c308326b2440878b989cd7f