### PR TITLE
Remove vehicle proximity check in auto tow

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -51,19 +51,6 @@ local function isAnySeatOccupied(veh)
   return false
 end
 
-local function isTooCloseToPlayers(coords, minDist)
-  for _, pid in ipairs(GetActivePlayers()) do
-    local ped = GetPlayerPed(pid)
-    if ped and ped ~= 0 then
-      local pcoords = GetEntityCoords(ped)
-      if #(pcoords - coords) <= (minDist or 25.0) then
-        return true
-      end
-    end
-  end
-  return false
-end
-
 local function tryDeleteVehicle(veh)
   if not DoesEntityExist(veh) then return false end
 
@@ -122,9 +109,6 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
 
       -- No borrar si hay alguien a bordo
       if isAnySeatOccupied(veh) then goto continue end
-
-      local coords = GetEntityCoords(veh)
-      if isTooCloseToPlayers(coords, cfg.minDist) then goto continue end
 
       -- Solo el owner de la entidad elimina para evitar duplicados
       local owner = NetworkGetEntityOwner(veh)

--- a/autotow/config.lua
+++ b/autotow/config.lua
@@ -11,7 +11,7 @@ Config.IntervalMinutes = 30
 Config.AlertDuration = 20
 
 -- Distancia mínima a cualquier jugador para poder borrar un vehículo
-Config.MinDistanceFromAnyPlayer = 10.0
+Config.MinDistanceFromAnyPlayer = 0
 
 -- Exclusiones / filtros
 Config.SkipEmergencyVehicles = true      -- Clase 18


### PR DESCRIPTION
## Summary
- disable minimum distance requirement by setting `MinDistanceFromAnyPlayer` to 0
- drop `isTooCloseToPlayers` helper and its use so vehicles are removed even near players

## Testing
- `luac -p autotow/config.lua` *(fails: unexpected symbol near ``)*
- `luac -p autotow/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b26f079b108326b6292c3d7e918038