### PR TITLE
feat: announce post-cleanup message

### DIFF
--- a/autotow/config.lua
+++ b/autotow/config.lua
@@ -39,6 +39,10 @@ Config.AlertText   = 'Se eliminarán vehículos desocupados en breve.'
 Config.CancelTitle = 'LIMPIEZA CANCELADA'
 Config.CancelText  = 'Un administrador canceló la limpieza.'
 
+-- Mensaje al completar la limpieza
+Config.CleanupCompleteTitle = 'LIMPIEZA COMPLETA'
+Config.CleanupCompleteText  = 'La grúa pasó y las calles fueron limpiadas.'
+
 -- Mensajes escalonados de advertencia antes de la limpieza
 Config.CountdownMessages = {
   ['10m'] = 'Se eliminarán vehículos desocupados en 10 minutos.',

--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -11,9 +11,9 @@ local function debugPrint(msg)
 end
 
 -- Broadcast alert a todos
-local function broadcastAlert(text, duration)
+local function broadcastAlert(text, duration, title)
   TriggerClientEvent('invictus_tow:client:showAlert', -1, {
-    title = Config.AlertTitle,
+    title = title or Config.AlertTitle,
     text = text or Config.AlertText,
     duration = duration or Config.AlertDuration
   })
@@ -91,6 +91,7 @@ local function startCleanupCycle(manual)
     SetTimeout(8000, function()
       cleanupState.active = false
       print(('^2[%s]^7 Ciclo %s terminado.'):format(Config.ResourceName, token))
+      broadcastAlert(Config.CleanupCompleteText, nil, Config.CleanupCompleteTitle)
     end)
   end)
 end


### PR DESCRIPTION
## Summary
- notify all players when tow cleanup cycle finishes
- add configurable completion message

## Testing
- `luac -p autotow/server.lua autotow/client.lua`
- `luac -p autotow/server.lua autotow/config.lua autotow/client.lua` *(fails: autotow/config.lua:22: unexpected symbol near '`')*


------
https://chatgpt.com/codex/tasks/task_e_68b270fd7e108326b5501607fe91ba99