### PR TITLE
Include emergency and special vehicles in autotow

### DIFF
--- a/autotow/config.lua
+++ b/autotow/config.lua
@@ -14,16 +14,14 @@ Config.AlertDuration = 20
 Config.MinDistanceFromAnyPlayer = 0
 
 -- Exclusiones / filtros
-Config.SkipEmergencyVehicles = true      -- Clase 18
-Config.SkipBoatsAndAircraft = true       -- 14=boats, 15=heli, 16=planes, 21=trains
+Config.SkipEmergencyVehicles = false     -- Clase 18
+Config.SkipBoatsAndAircraft = false      -- 14=boats, 15=heli, 16=planes, 21=trains
 
 -- Lista de modelos prohibidos para borrar
-Config.BlacklistedModels = {
-  `police`, `police2`, `police3`, `police4`, `policeb`, `policet`, `sheriff`, `sheriff2`,
-}
+Config.BlacklistedModels = {}
 
 -- Clases a omitir además de las de arriba (puedes añadir más)
-Config.BlacklistedClasses = { 18 } -- emergencia
+Config.BlacklistedClasses = {}
 
 -- Comandos
 Config.CommandCancel = 'towcancel'


### PR DESCRIPTION
## Summary
- allow autotow to include emergency, boat, and aircraft vehicles
- clear blacklisted models and classes so all vehicles can be cleaned up

## Testing
- `luac -p autotow/config.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b272b1288883269a149482bbd4bdfc