### PR TITLE
Define zone lookup earlier to avoid nil calls

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -5,6 +5,7 @@ local JobsFile = _G.JobsFile
 local Runtime = { Jobs = {}, Zones = {} }
 local _lastCreate = {}
 local CreatedStashes = {}
+local findZoneById
 
 local function SanitizeShopItems(items)
   local list = {}
@@ -719,7 +720,7 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
 end)
 
 -- ===== Acciones seguras de zonas =====
-local function findZoneById(id)
+function findZoneById(id)
   for _, z in ipairs(Runtime.Zones) do
     if z.id == id then return z end
   end


### PR DESCRIPTION
## Summary
- Declare `findZoneById` before any event uses it and assign the function later

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `luac -p qb-jobcreator/server/main.lua`
- ❌ `fxserver +set sv_enforceGameBuild 2189` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b27b06a6c883268a06676390d14966