### PR TITLE
Improve zone detection and debugging for jobcreator zones

### DIFF
--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -66,6 +66,7 @@ Config.Zone = Config.Zone or {
   TextUIKey  = '[E]',
   ClearArea  = false,
   ClearRadius = 30.0,
+  Debug = false,
 }
 
 -- Plantilla de rangos (puedes añadir más entradas si lo necesitas)


### PR DESCRIPTION
## Summary
- Add debug flag for zone configuration
- Enforce unique zone names and enlarge detection area
- Enable `useZ` and optional `debugPoly` when creating zones

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b27c557b1c8326ac91de477062d8d5