### PR TITLE
Add support for crafting multiple items in job creator

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -198,8 +198,9 @@ end)
 RegisterNUICallback('craft', function(data, cb)
   local zoneId = data and (data.zoneId or data.zone)
   local recipe = data and data.recipe
+  local amount = tonumber(data and data.amount) or 1
   if zoneId and recipe then
-    TriggerServerEvent('qb-jobcreator:server:craft', zoneId, recipe)
+    TriggerServerEvent('qb-jobcreator:server:craft', zoneId, recipe, amount)
   end
   cb({ ok = true })
 end)


### PR DESCRIPTION
## Summary
- Send crafted amount from NUI to server
- Validate and consume materials based on desired amount
- Produce multiple outputs and scale progress for bulk crafting

## Testing
- `luac -p qb-jobcreator/client/main.lua qb-jobcreator/server/main.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2a189de84832695894bc4a2f994b9