### PR TITLE
feat: color-code crafting recipes by material availability

### DIFF
--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -1067,10 +1067,14 @@ const CraftUI = (() => {
           : 'nui://qb-inventory/html/images/';
         const imgSrc = `${base}${out}.png`;
         let maxCraft = Infinity;
+        let haveAll = true;
+        let haveAny = false;
         const inputs = (rec.inputs || [])
           .map(i => {
             const need = i.amount || i.qty || 1;
             const have = inventory[i.item] || 0;
+            if (have < need) haveAll = false;
+            if (have > 0) haveAny = true;
             maxCraft = Math.min(maxCraft, Math.floor(have / need) || 0);
             const cls = have < need ? ' class="missing"' : '';
             return `<li${cls}>${need}x ${i.item}</li>`;
@@ -1078,10 +1082,20 @@ const CraftUI = (() => {
           .join('');
         if (maxCraft === Infinity) maxCraft = 0;
         const disabled = maxCraft <= 0 ? ' disabled' : '';
+        let status;
+        if ((rec.inputs || []).length === 0 || haveAll) status = 'green';
+        else if (haveAny) status = 'yellow';
+        else status = 'red';
         card.innerHTML = `
           <img src="${imgSrc}" alt="${out}" onerror="this.onerror=null;this.src='logo.png';">
           <div class="materials"><strong>${rec.label || out}</strong><ul>${inputs}</ul></div>
           <button class="btn craft-btn" data-recipe="${name}" data-max="${maxCraft}"${disabled}>Fabricar</button>`;
+        card.classList.add(`status-${status}`);
+        card.title = status === 'green'
+          ? 'Tienes todos los materiales'
+          : status === 'yellow'
+            ? 'Te faltan algunos materiales'
+            : 'No tienes materiales';
         wrap.appendChild(card);
       });
     }

--- a/qb-jobcreator/web/index.html
+++ b/qb-jobcreator/web/index.html
@@ -125,6 +125,11 @@
     <div class="craft-panel">
       <div id="craft-categories" class="craft-cats"></div>
       <div id="craft-inventory" class="craft-inv"></div>
+      <div class="craft-info">
+        <span class="status-green">Verde: todos los materiales</span>,
+        <span class="status-yellow">Amarillo: faltan algunos</span>,
+        <span class="status-red">Rojo: ninguno</span>
+      </div>
       <div id="craft-list"></div>
       <div id="craft-progress" class="craft-progress hidden"><div class="bar"></div></div>
     </div>

--- a/qb-jobcreator/web/style.css
+++ b/qb-jobcreator/web/style.css
@@ -61,3 +61,10 @@ body{margin:0;background:transparent;color:var(--text);font:14px/1.4 Inter,syste
 .craft-inv .inv-item{background:var(--bg2);padding:4px 8px;border-radius:8px}
 .craft-progress{position:absolute;left:20px;right:20px;bottom:20px;height:8px;background:#1f2433;border-radius:6px;overflow:hidden}
 .craft-progress .bar{height:100%;width:0;background:var(--primary);transition:width .2s}
+.craft-info{margin-bottom:10px;font-size:12px;color:var(--muted)}
+.status-green{color:var(--ok)}
+.status-yellow{color:var(--warn)}
+.status-red{color:var(--danger)}
+.craft-item.status-green{border-left:4px solid var(--ok);background:rgba(16,185,129,.1)}
+.craft-item.status-yellow{border-left:4px solid var(--warn);background:rgba(245,158,11,.1)}
+.craft-item.status-red{border-left:4px solid var(--danger);background:rgba(239,68,68,.1)}


### PR DESCRIPTION
## Summary
- flag each recipe with green/yellow/red status based on available materials
- style crafting cards with new status colors and add legend/tooltip text

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a2990e60832693cddb6f357db28d