### PR TITLE
feat: enhance crafting interface with search and queue panels

### DIFF
--- a/qb-jobcreator/web/index.html
+++ b/qb-jobcreator/web/index.html
@@ -130,7 +130,10 @@
         <span class="status-yellow">Amarillo: faltan algunos</span>,
         <span class="status-red">Rojo: ninguno</span>
       </div>
+      <input id="craft-search" class="craft-search" type="text" placeholder="Buscar recetas..." />
       <div id="craft-list"></div>
+      <div id="craft-pending" class="panel craft-pending"></div>
+      <div id="craft-collect" class="panel craft-collect"></div>
       <div id="craft-progress" class="craft-progress hidden"><div class="bar"></div></div>
     </div>
   </div>

--- a/qb-jobcreator/web/style.css
+++ b/qb-jobcreator/web/style.css
@@ -1,6 +1,16 @@
-:root{--bg:#0f1218;--bg2:#121723;--text:#edf1f7;--muted:#8a94a6;--primary:#4f46e5;--card:#161b2a;--ok:#10b981;--warn:#f59e0b;--danger:#ef4444}
+:root{
+  --color-bg:#0f1218;
+  --color-bg-alt:#121723;
+  --color-text:#edf1f7;
+  --color-muted:#8a94a6;
+  --color-primary:#4f46e5;
+  --color-card:#161b2a;
+  --color-success:#10b981;
+  --color-warning:#f59e0b;
+  --color-danger:#ef4444;
+}
 *{box-sizing:border-box}html,body{height:100%}
-body{margin:0;background:transparent;color:var(--text);font:14px/1.4 Inter,system-ui,Segoe UI,Roboto,Arial}
+body{margin:0;background:transparent;color:var(--color-text);font:14px/1.4 Inter,system-ui,Segoe UI,Roboto,Arial}
 .hidden{display:none}
 .app.hidden{display:none!important}
 .modal.hidden{display:none!important}
@@ -14,30 +24,30 @@ body{margin:0;background:transparent;color:var(--text);font:14px/1.4 Inter,syste
 .brand img{width:28px;height:28px;border-radius:6px;object-fit:cover}
 .drag-hint{color:#94a3b8;font-size:12px}
 .wrap{display:flex;height:calc(84vh - 48px)}
-.sidebar{width:220px;background:var(--bg2);display:flex;flex-direction:column;padding:12px 10px;border-right:1px solid #1f2433}
+.sidebar{width:220px;background:var(--color-bg-alt);display:flex;flex-direction:column;padding:12px 10px;border-right:1px solid #1f2433}
 .sidebar nav{display:flex;flex-direction:column;gap:8px}
-.sidebar button{background:transparent;border:0;color:var(--muted);padding:10px 12px;text-align:left;border-radius:10px;cursor:pointer}
-.sidebar button.active,.sidebar button:hover{background:#1a2031;color:var(--text)}
+.sidebar button{background:transparent;border:0;color:var(--color-muted);padding:10px 12px;text-align:left;border-radius:10px;cursor:pointer}
+.sidebar button.active,.sidebar button:hover{background:#1a2031;color:var(--color-text)}
 .content{flex:1;padding:18px 22px;overflow:auto}
 .cards{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
 .cards.small{grid-template-columns:repeat(3,1fr)}
-.card{background:var(--card);padding:16px;border-radius:14px;border:1px solid #1f2433}
-.card .h{color:var(--muted);font-size:12px}
+.card{background:var(--color-card);padding:16px;border-radius:14px;border:1px solid #1f2433}
+.card .h{color:var(--color-muted);font-size:12px}
 .card .b{font-size:24px;font-weight:700;margin-top:6px}
-.panel{background:var(--card);padding:16px;border-radius:14px;margin-top:16px;border:1px solid #1f2433}
+.panel{background:var(--color-card);padding:16px;border-radius:14px;margin-top:16px;border:1px solid #1f2433}
 .panel-h{font-weight:700;margin-bottom:8px}
 .toolbar{display:flex;gap:8px;margin:10px 0}
 .btn{background:#232a3d;border:0;color:#cbd5e1;padding:10px 14px;border-radius:10px;cursor:pointer}
-.btn.primary{background:var(--primary);color:white}
-.btn.danger{background:var(--danger)}
-.table{width:100%;border-collapse:collapse;background:var(--card);border-radius:12px;overflow:hidden}
+.btn.primary{background:var(--color-primary);color:white}
+.btn.danger{background:var(--color-danger)}
+.table{width:100%;border-collapse:collapse;background:var(--color-card);border-radius:12px;overflow:hidden}
 .table th,.table td{padding:10px 12px;border-bottom:1px solid #20263a}
 .table th{color:#94a3b8;text-align:left;font-weight:600}
 .badge{padding:2px 8px;border-radius:999px;font-size:12px}
 .badge.ok{background:#065f46;color:#a7f3d0}
 .badge.off{background:#3f3f46;color:#e4e4e7}
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.45);display:grid;place-items:center}
-.modal-body{width:520px;background:var(--card);border:1px solid #1f2433;border-radius:16px;padding:16px}
+.modal-body{width:520px;background:var(--color-card);border:1px solid #1f2433;border-radius:16px;padding:16px}
 .modal-h{font-weight:800;margin-bottom:12px}
 .input,select,textarea{width:100%;padding:10px 12px;border-radius:10px;border:1px solid #2a3146;background:#0f1422;color:#e5e7eb}
 .row{display:grid;grid-template-columns:1fr 1fr;gap:10px}
@@ -46,25 +56,41 @@ body{margin:0;background:transparent;color:var(--text);font:14px/1.4 Inter,syste
 /* ===== Crafteo ===== */
 .craft.hidden{display:none!important}
 .craft{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:rgba(0,0,0,.45);z-index:9999}
-.craft-panel{background:var(--card);padding:20px;border-radius:12px;max-height:80vh;overflow-y:auto;min-width:320px;position:relative}
+.craft-panel{background:var(--color-card);padding:20px;border-radius:12px;max-height:80vh;overflow-y:auto;min-width:320px;position:relative}
 .craft-item{display:flex;align-items:center;gap:10px;margin-bottom:12px}
 .craft-item img{width:64px;height:64px;object-fit:contain;border-radius:6px}
 .craft-item .materials{flex:1;font-size:14px}
 .craft-item .materials ul{margin:0;padding-left:16px}
-.craft-item .materials .missing{color:var(--danger)}
+.craft-item .materials .missing{color:var(--color-danger)}
 .craft-item button{padding:8px 12px}
 
 .craft-cats{display:flex;gap:8px;margin-bottom:10px}
 .craft-cats .cat-btn{background:#232a3d;border:0;color:#cbd5e1;padding:6px 10px;border-radius:8px;cursor:pointer}
-.craft-cats .cat-btn.active{background:var(--primary);color:white}
+.craft-cats .cat-btn.active{background:var(--color-primary);color:white}
 .craft-inv{display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;font-size:13px}
-.craft-inv .inv-item{background:var(--bg2);padding:4px 8px;border-radius:8px}
+.craft-inv .inv-item{background:var(--color-bg-alt);padding:4px 8px;border-radius:8px}
 .craft-progress{position:absolute;left:20px;right:20px;bottom:20px;height:8px;background:#1f2433;border-radius:6px;overflow:hidden}
-.craft-progress .bar{height:100%;width:0;background:var(--primary);transition:width .2s}
-.craft-info{margin-bottom:10px;font-size:12px;color:var(--muted)}
-.status-green{color:var(--ok)}
-.status-yellow{color:var(--warn)}
-.status-red{color:var(--danger)}
-.craft-item.status-green{border-left:4px solid var(--ok);background:rgba(16,185,129,.1)}
-.craft-item.status-yellow{border-left:4px solid var(--warn);background:rgba(245,158,11,.1)}
-.craft-item.status-red{border-left:4px solid var(--danger);background:rgba(239,68,68,.1)}
+.craft-progress .bar{height:100%;width:0;background:var(--color-primary);transition:width .2s}
+.craft-info{margin-bottom:10px;font-size:12px;color:var(--color-muted)}
+.status-green{color:var(--color-success)}
+.status-yellow{color:var(--color-warning)}
+.status-red{color:var(--color-danger)}
+.craft-item.status-green{border-left:4px solid var(--color-success);background:rgba(16,185,129,.1)}
+.craft-item.status-yellow{border-left:4px solid var(--color-warning);background:rgba(245,158,11,.1)}
+.craft-item.status-red{border-left:4px solid var(--color-danger);background:rgba(239,68,68,.1)}
+
+.craft-search{width:100%;padding:8px 10px;margin-bottom:10px;border-radius:8px;border:1px solid var(--color-muted);background:var(--color-bg-alt);color:var(--color-text)}
+.icon-wrap{display:flex;gap:4px}
+.icon-wrap img{width:64px;height:64px;object-fit:contain;border-radius:6px}
+.craft-item .desc{margin:2px 0 4px;font-size:12px;color:var(--color-muted)}
+.craft-item .outputs{margin-top:4px;font-size:13px;color:var(--color-muted)}
+.craft-pending,.craft-collect{margin-top:10px}
+.craft-pending .q-item,.craft-collect .q-ready{margin-bottom:6px}
+
+@media (max-width:768px){
+  .window{width:90vw;height:90vh}
+  .wrap{flex-direction:column}
+  .sidebar{width:100%;flex-direction:row;overflow-x:auto}
+  .sidebar nav{flex-direction:row}
+  .cards{grid-template-columns:repeat(2,1fr)}
+}


### PR DESCRIPTION
## Summary
- add search bar and pending/collect panels to crafting UI
- filter recipes in real time and show detailed outputs
- refactor styles with CSS variables and responsive tweaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2addd3d708326bad109d7961dcc55