### PR TITLE
Integrate Invictus crafting UI with jobcreator zones

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -195,11 +195,7 @@ end
 
 local function openCraftMenu(z)
   if not z or not z.id then return end
-  QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
-    SetNuiFocus(true, true)
-    SetNuiFocusKeepInput(false)
-    SendNUIMessage({ action = 'openCraft', payload = { zone = z.id, zoneId = z.id, recipes = recipes or {} } })
-  end, z.id)
+  TriggerEvent('qb-jobcreator:client:openCrafting', z.id)
 end
 
 -- =====================================

--- a/qb-jobcreator/fxmanifest.lua
+++ b/qb-jobcreator/fxmanifest.lua
@@ -12,7 +12,9 @@ ui_page 'web/index.html'
 files {
   'web/index.html',
   'web/style.css',
+  'web/crafting.css',
   'web/app.js',
+  'web/crafting.js',
   'web/logo.png',
 }
 

--- a/qb-jobcreator/web/crafting.css
+++ b/qb-jobcreator/web/crafting.css
@@ -1,0 +1,79 @@
+* { box-sizing: border-box; user-select: none; }
+body { margin: 0; font-family: Inter, system-ui, Arial; background: transparent; }
+
+.hidden { display: none !important; }
+
+.craft-app {
+  position: absolute; inset: 5% 5%; background: rgba(7,20,18,.92);
+  border: 1px solid rgba(255,255,255,.08); border-radius: 12px;
+  color: #e8f0ef; display: grid; grid-template-columns: 1fr 320px; grid-template-rows: auto auto 1fr;
+  gap: 12px; padding: 16px; overflow: hidden;
+}
+
+.craft-app .header { grid-column: 1 / span 2; display: flex; align-items: center; justify-content: space-between; }
+.craft-app .title { font-size: 24px; letter-spacing: .5px; display: flex; align-items: center; gap: 10px; }
+.craft-app .tag { font-size: 12px; background: #1e2f2c; padding: 4px 8px; border-radius: 999px; border: 1px solid rgba(255,255,255,.08); }
+
+.craft-app .search { position: relative; }
+.craft-app .search input {
+  background: #0d1715; color: #cfe3e0; border: 1px solid rgba(255,255,255,.1);
+  padding: 10px 34px 10px 12px; border-radius: 8px; width: 260px; outline: none;
+}
+.craft-app .search i { position: absolute; right: 10px; top: 10px; opacity: .7; }
+
+.craft-app .statusBar { grid-column: 1 / span 2; display: grid; grid-template-columns: 1fr 140px; gap: 10px; align-items: center; }
+.craft-app .progress { height: 18px; background: #0f1716; border: 1px solid rgba(255,255,255,.08); border-radius: 8px; overflow: hidden; }
+.craft-app .progress > div { height: 100%; width: 0%; background: linear-gradient(90deg,#8dd4b4,#53a88c); transition: width .2s; }
+.craft-app .time { font-size: 12px; opacity: .8; text-align: right; }
+
+.craft-app .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding-bottom: 12px; overflow: auto; }
+.craft-app .card {
+  background: #0e1917; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px;
+  display: grid; grid-template-rows: auto auto auto; gap: 6px;
+}
+.craft-app .card .img { height: 96px; display: grid; place-items: center; }
+.craft-app .card .img img { max-height: 96px; max-width: 100px; filter: drop-shadow(0 0 10px rgba(0,0,0,.2)); }
+
+.craft-app .card .title { text-align: center; font-weight: 600; }
+.craft-app .card .hint { font-size: 12px; opacity: .7; text-align: center; }
+.craft-app .card .qtyRow { display: grid; grid-template-columns: 32px 1fr 32px; gap: 6px; align-items: center; }
+.craft-app .small { height: 32px; background: #142321; border: 1px solid rgba(255,255,255,.08); color: #cfe3e0; border-radius: 8px; }
+.craft-app .card .btn { margin-top: 6px; }
+
+.craft-app .card.locked { filter: grayscale(100%); opacity: .65; }
+.craft-app .card .lock { position: absolute; top: 8px; right: 8px; font-size: 14px; opacity: .8; }
+
+.craft-app .btn {
+  width: 100%; padding: 10px 12px; border-radius: 8px; border: 1px solid rgba(255,255,255,.12);
+  background: #173430; color: #e8f0ef; font-weight: 700; cursor: pointer;
+}
+.craft-app .btn.primary { background: linear-gradient(90deg,#53a88c,#2f7a62); }
+.craft-app .btn.danger { background: #512e2e; }
+
+.craft-app .sidebar { overflow: auto; display: grid; grid-auto-rows: min-content; gap: 12px; }
+.craft-app .panel { background:#0e1917; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 10px; }
+.craft-app .panel-title { font-weight: 700; margin-bottom: 8px; }
+.craft-app .panel-body { display: grid; gap: 6px; }
+.craft-app .panel-body.empty { opacity: .7; font-size: 13px; }
+
+.craft-app .queueItem, .craft-app .collectItem {
+  display: grid; grid-template-columns: 36px 1fr auto; align-items: center; gap: 8px;
+  padding: 8px; border: 1px solid rgba(255,255,255,.06); border-radius: 10px; background: #0c1513;
+}
+.craft-app .badge { background: #112320; padding: 2px 6px; border-radius: 6px; font-size: 11px; }
+
+.craft-modal { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: grid; place-items: center; }
+.craft-modal .modal-inner { width: 540px; background:#0d1816; border:1px solid rgba(255,255,255,.1); border-radius: 12px; overflow: hidden; }
+.craft-modal .modal-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,.08); }
+.craft-modal .xbtn { background: transparent; border: 0; color: #e8f0ef; font-size: 18px; cursor: pointer; }
+
+.craft-modal .modal-body { padding: 12px 16px; display: grid; gap: 10px; }
+.craft-app .mats, .craft-app .outs { display: grid; gap: 8px; }
+.craft-app .mat, .craft-app .out { display: grid; grid-template-columns: 40px 1fr auto; gap: 8px; align-items: center; }
+.craft-app .mats .need { font-size: 12px; opacity: .8; }
+.craft-app .qty { display: grid; grid-template-columns: 48px 1fr 48px; gap: 8px; }
+.craft-app .qty input { background:#0f1a18; border:1px solid rgba(255,255,255,.08); color:#cfe3e0; padding:8px; border-radius:8px; text-align:center; }
+
+.craft-app .state-all { outline: 2px solid #45d483; }
+.craft-app .state-some { outline: 2px solid #d1b73f; }
+.craft-app .state-none { outline: 2px solid #c24b4b; }

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -1,0 +1,170 @@
+const CraftApp = {
+  locale: {},
+  data: null,
+  images: 'nui://ox_inventory/web/images/',
+  filterText: '',
+  selected: null
+};
+
+const $ = (sel) => document.querySelector(sel);
+
+window.addEventListener('message', (e) => {
+  const msg = e.data || {};
+  if (msg.action === 'open') {
+    CraftApp.locale = msg.locale || {};
+    CraftApp.images = msg.images || CraftApp.images;
+    $('#craftTitleText').innerText = CraftApp.locale.ui_title || 'KITCHEN';
+    $('#craftCategoryTag').innerText = CraftApp.locale.ui_tab_food || 'FOOD';
+    $('#craftPendingTitle').innerText = CraftApp.locale.queue_pending || 'PENDING ITEMS';
+    $('#craftCollectTitle').innerText = CraftApp.locale.queue_collect || 'ITEMS TO COLLECT';
+    $('#craftBtnLeaveAll').innerText = CraftApp.locale.leave_all || 'LEAVE ALL QUEUES';
+    $('#craftSearchInput').placeholder = CraftApp.locale.search || 'Search...';
+    document.getElementById('craftApp').classList.remove('hidden');
+  }
+  if (msg.action === 'init') {
+    CraftApp.data = msg.data; renderAll();
+  }
+  if (msg.action === 'update') {
+    CraftApp.data = msg.data; renderSidebars();
+  }
+});
+
+function renderAll(){
+  renderCards();
+  renderSidebars();
+  setupSearch();
+}
+
+function iconPath(item){ return `${CraftApp.images}${item}.png`; }
+function cardStateClass(status){ return status === 'all' ? 'state-all' : status === 'some' ? 'state-some' : 'state-none'; }
+
+function renderCards(){
+  const grid = document.getElementById('craftGrid'); grid.innerHTML = '';
+  const recipes = (CraftApp.data?.recipes || []).filter(r => {
+    const t = (CraftApp.filterText||'').toLowerCase();
+    if (!t) return true;
+    return (r.label || r.item).toLowerCase().includes(t) || r.item.toLowerCase().includes(t);
+  });
+
+  for (const r of recipes){
+    const card = document.createElement('div');
+    card.className = `card ${cardStateClass(r.status)} ${(r.lockedByJob || r.lockedBySkill) ? 'locked' : ''}`;
+    card.innerHTML = `
+      <div class="img"><img src="${iconPath(r.item)}" onerror="this.style.opacity=.2"></div>
+      <div class="title">${r.label || r.item}</div>
+      <div class="hint">${CraftApp.locale.click_to_info || 'Click to view information'}</div>
+      <div class="qtyRow">
+        <button class="small dec">-</button>
+        <input class="qtyInput" type="number" min="1" value="1">
+        <button class="small inc">+</button>
+      </div>
+      <button class="btn primary craftBtn">${CraftApp.locale.craft || 'CRAFT'}</button>
+      ${(r.lockedByJob || r.lockedBySkill) ? `<i class="fa-solid fa-lock lock" title="Locked"></i>` : ''}
+    `;
+    const qtyInput = card.querySelector('.qtyInput');
+    card.querySelector('.dec').onclick = ()=> qtyInput.value = Math.max(1, Number(qtyInput.value)-1);
+    card.querySelector('.inc').onclick = ()=> qtyInput.value = Number(qtyInput.value)+1;
+    const openModal = () => showModal(r);
+    card.querySelector('.img').onclick = openModal;
+    card.querySelector('.title').onclick = openModal;
+    card.querySelector('.craftBtn').onclick = ()=>{
+      if (r.lockedByJob || r.lockedBySkill) return;
+      fetchNui('craft', { item: r.item, amount: Number(qtyInput.value||1) });
+    };
+    grid.appendChild(card);
+  }
+}
+
+function renderSidebars(){
+  const q = CraftApp.data?.queue || [];
+  const ready = CraftApp.data?.ready || [];
+
+  const pending = document.getElementById('craftPendingList'); pending.innerHTML=''; pending.classList.toggle('empty', q.length===0);
+  for (const it of q){
+    const row = document.createElement('div');
+    row.className='queueItem';
+    row.innerHTML = `
+      <img src="${iconPath(it.item)}" width="32" height="32" onerror="this.style.opacity=.2">
+      <div>
+        <div><b>${it.label}</b></div>
+        <div class="badge">${it.amount}x</div>
+      </div>
+      <div class="badge">${CraftApp.locale.crafting || 'Crafting'}</div>
+    `;
+    pending.appendChild(row);
+  }
+
+  const cl = document.getElementById('craftCollectList'); cl.innerHTML=''; cl.classList.toggle('empty', ready.length===0);
+  for (const it of ready){
+    const row = document.createElement('div');
+    row.className='collectItem';
+    row.innerHTML = `
+      <img src="${iconPath(it.outputs?.[0]?.item || 'unknown')}" width="32" height="32" onerror="this.style.opacity=.2">
+      <div>
+        <div><b>${it.label}</b></div>
+        <div class="badge">${new Date(it.timestamp*1000).toLocaleTimeString()}</div>
+      </div>
+      <button class="small collectBtn">${CraftApp.locale.collect || 'COLLECT'}</button>
+    `;
+    row.querySelector('.collectBtn').onclick = ()=> fetchNui('collect', { id: it.id });
+    cl.appendChild(row);
+  }
+}
+
+function setupSearch(){
+  const s = document.getElementById('craftSearchInput');
+  s.oninput = () => { CraftApp.filterText = s.value.trim(); renderCards(); };
+}
+
+function showModal(r){
+  CraftApp.selected = JSON.parse(JSON.stringify(r));
+  document.getElementById('craftModalTitle').innerText = `${(CraftApp.locale.recipe_for||'RECIPE FOR')} ${r.label || r.item}`;
+  const mats = document.getElementById('craftModalMats'); mats.innerHTML='';
+  for (const m of r.materials||[]){
+    const row = document.createElement('div');
+    row.className='mat';
+    row.innerHTML = `
+      <img src="${iconPath(m.item)}" width="36" height="36" onerror="this.style.opacity=.2">
+      <div>${m.item}</div>
+      <div class="need">${m.have||0}/${m.need}${m.noConsume?' (tool)':''}</div>
+    `;
+    mats.appendChild(row);
+  }
+  const outs = document.getElementById('craftModalOuts'); outs.innerHTML='';
+  for (const o of r.outputs||[]){
+    const row = document.createElement('div');
+    row.className='out';
+    row.innerHTML = `
+      <img src="${iconPath(o.item)}" width="36" height="36" onerror="this.style.opacity=.2">
+      <div>${o.item}</div>
+      <div class="need">x${o.amount}</div>
+    `;
+    outs.appendChild(row);
+  }
+  document.getElementById('craftQty').value = 1;
+  document.getElementById('craftModal').classList.remove('hidden');
+}
+
+document.getElementById('craftModalClose').onclick = ()=> document.getElementById('craftModal').classList.add('hidden');
+document.getElementById('craftDec').onclick = ()=> document.getElementById('craftQty').value = Math.max(1, Number(document.getElementById('craftQty').value)-1);
+document.getElementById('craftInc').onclick = ()=> document.getElementById('craftQty').value = Number(document.getElementById('craftQty').value)+1;
+document.getElementById('craftBtnCraft').onclick = ()=>{
+  if (!CraftApp.selected) return;
+  fetchNui('craft', { item: CraftApp.selected.item, amount: Number(document.getElementById('craftQty').value||1) });
+  document.getElementById('craftModal').classList.add('hidden');
+};
+
+document.getElementById('craftBtnLeaveAll').onclick = ()=> fetchNui('leaveAll', {});
+
+function fetchNui(name, data){
+  fetch(`https://${GetParentResourceName()}/${name}`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+    body: JSON.stringify(data||{})
+  })
+}
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape'){
+    fetchNui('close', {}); document.getElementById('craftApp').classList.add('hidden'); document.getElementById('craftModal').classList.add('hidden');
+  }
+});

--- a/qb-jobcreator/web/index.html
+++ b/qb-jobcreator/web/index.html
@@ -5,6 +5,9 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Creador de Trabajos</title>
   <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+  <link rel="stylesheet" href="crafting.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
@@ -119,25 +122,66 @@
       </div>
     </div>
   </div>
-
-  <!-- Panel de Crafteo -->
-  <div id="craft" class="craft hidden">
-    <div class="craft-panel">
-      <div id="craft-categories" class="craft-cats"></div>
-      <div id="craft-inventory" class="craft-inv"></div>
-      <div class="craft-info">
-        <span class="status-green">Verde: todos los materiales</span>,
-        <span class="status-yellow">Amarillo: faltan algunos</span>,
-        <span class="status-red">Rojo: ninguno</span>
+  <div id="craftApp" class="craft-app hidden">
+    <div class="header">
+      <div class="title">
+        <i class="fa-solid fa-utensils"></i>
+        <span id="craftTitleText">KITCHEN</span>
+        <span id="craftCategoryTag" class="tag">FOOD</span>
       </div>
-      <input id="craft-search" class="craft-search" type="text" placeholder="Buscar recetas..." />
-      <div id="craft-list"></div>
-      <div id="craft-pending" class="panel craft-pending"></div>
-      <div id="craft-collect" class="panel craft-collect"></div>
-      <div id="craft-progress" class="craft-progress hidden"><div class="bar"></div></div>
+      <div class="search">
+        <input id="craftSearchInput" type="text" placeholder="Search..." />
+        <i class="fa-solid fa-magnifying-glass"></i>
+      </div>
+    </div>
+
+    <div class="statusBar">
+      <div id="craftCraftingBar" class="progress"><div id="craftProgressInner"></div></div>
+      <div id="craftTimeLeft" class="time">Time left: --</div>
+    </div>
+
+    <div class="grid" id="craftGrid"></div>
+
+    <aside class="sidebar">
+      <div class="panel">
+        <div class="panel-title" id="craftPendingTitle">PENDING ITEMS</div>
+        <div id="craftPendingList" class="panel-body empty">You have no items in the crafting queue</div>
+      </div>
+
+      <div class="panel">
+        <div class="panel-title" id="craftCollectTitle">ITEMS TO COLLECT</div>
+        <div id="craftCollectList" class="panel-body empty">You have no items to collect</div>
+      </div>
+
+      <div class="panel">
+        <button id="craftBtnLeaveAll" class="btn danger">LEAVE ALL QUEUES</button>
+      </div>
+    </aside>
+
+    <div id="craftModal" class="craft-modal hidden">
+      <div class="modal-inner">
+        <div class="modal-header">
+          <div id="craftModalTitle">RECIPE FOR</div>
+          <button id="craftModalClose" class="xbtn">✕</button>
+        </div>
+        <div class="modal-body">
+          <div id="craftModalMats" class="mats"></div>
+          <div class="receiveTitle">YOU WILL RECEIVE:</div>
+          <div id="craftModalOuts" class="outs"></div>
+          <div class="qty">
+            <button class="small" id="craftDec">-</button>
+            <input id="craftQty" type="number" value="1" min="1" />
+            <button class="small" id="craftInc">+</button>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button id="craftBtnCraft" class="btn primary">CRAFT</button>
+        </div>
+      </div>
     </div>
   </div>
 
   <script src="app.js"></script>
+  <script src="crafting.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed Invictus Craft web UI and assets into jobcreator NUI
- forward crafting callbacks to new open/init/update NUI messages
- open crafting interface when interacting with jobcreator crafting zones

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b2bd9fa8448326928f5746fed50497