### PR TITLE
Use dedicated openCraft action for crafting interface

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -236,7 +236,7 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
   craftZone = zoneId
   uiOpen = true
   SetNuiFocus(true, true)
-  SendNUIMessage({ action = 'open', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = Config and Config.InventoryImagePath })
+  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = Config and Config.InventoryImagePath })
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
     QBCore.Functions.TriggerCallback('qb-jobcreator:server:getQueue', function(res)
       local ready = {}

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -10,7 +10,7 @@ const $ = (sel) => document.querySelector(sel);
 
 window.addEventListener('message', (e) => {
   const msg = e.data || {};
-  if (msg.action === 'open') {
+  if (msg.action === 'openCraft') {
     CraftApp.locale = msg.locale || {};
     CraftApp.images = msg.images || CraftApp.images;
     $('#craftTitleText').innerText = CraftApp.locale.ui_title || 'KITCHEN';


### PR DESCRIPTION
## Summary
- Prevent conflicts by changing crafting NUI action to `openCraft`
- Update crafting web listener to handle new `openCraft` action

## Testing
- `luac -p qb-jobcreator/client/main.lua`
- `node --check qb-jobcreator/web/crafting.js`
- `jobcreator` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c7c77fe4832697c04cb19c5e34b5