### PR TITLE
feat: add crafting table callback for jobcreator

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -206,6 +206,12 @@ RegisterNUICallback('createZone', function(data, cb) TriggerServerEvent('qb-jobc
 RegisterNUICallback('deleteZone', function(data, cb) TriggerServerEvent('qb-jobcreator:server:deleteZone', data.id); cb({ ok = true }) end)
 RegisterNUICallback('getCoords', function(_, cb) local p = GetEntityCoords(PlayerPedId()); cb({ x = p.x, y = p.y, z = p.z }) end)
 
+RegisterNUICallback('getCraftingTable', function(data, cb)
+  QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingTable', function(list)
+    cb(list or {})
+  end, data and data.zoneId)
+end)
+
 -- Lista de cercanos (por si la UI lo usa)
 RegisterNUICallback('nearbyPlayers', function(data, cb)
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getNearbyPlayers', function(list)

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -402,7 +402,7 @@ QBCore.Functions.CreateCallback('qb-jobcreator:server:getZones', function(src, c
   cb(list)
 end)
 
-QBCore.Functions.CreateCallback('qb-jobcreator:server:getCraftingData', function(src, cb, zoneId)
+local function CollectCraftingData(src, zoneId)
   local function fmt(name, recipe)
     return {
       name = name,
@@ -417,7 +417,7 @@ QBCore.Functions.CreateCallback('qb-jobcreator:server:getCraftingData', function
 
   if zoneId then
     local ok, zone = playerInJobZone(src, findZoneById(zoneId), 'crafting')
-    if not ok then cb({}) return end
+    if not ok then return {} end
 
     local list = {}
     local data = zone.data or {}
@@ -436,15 +436,22 @@ QBCore.Functions.CreateCallback('qb-jobcreator:server:getCraftingData', function
         if r then list[#list + 1] = fmt(name, r) end
       end
     end
-    cb(list)
-    return
+    return list
   end
 
   local all = {}
   for name, r in pairs(Config.CraftingRecipes or {}) do
     all[#all + 1] = fmt(name, r)
   end
-  cb(all)
+  return all
+end
+
+QBCore.Functions.CreateCallback('qb-jobcreator:server:getCraftingData', function(src, cb, zoneId)
+  cb(CollectCraftingData(src, zoneId))
+end)
+
+QBCore.Functions.CreateCallback('qb-jobcreator:server:getCraftingTable', function(src, cb, zoneId)
+  cb(CollectCraftingData(src, zoneId))
 end)
 
 RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -224,7 +224,7 @@ const App = (() => {
       applyBranding(pay.branding);
       applyScope();
 
-      postJ('getCraftingData').then((r) => {
+      postJ('getCraftingTable').then((r) => {
         if (Array.isArray(r)) { const o = {}; r.forEach((x) => { if (x && x.name) o[x.name] = x; }); state.recipes = o; }
         else { state.recipes = r || {}; }
       });
@@ -248,7 +248,7 @@ const App = (() => {
       if (payload.scope) state.scope = payload.scope;
       applyBranding(payload.branding);
       applyScope();
-      postJ('getCraftingData').then((r) => {
+      postJ('getCraftingTable').then((r) => {
         if (Array.isArray(r)) { const o = {}; r.forEach((x) => { if (x && x.name) o[x.name] = x; }); state.recipes = o; }
         else { state.recipes = r || {}; }
       });
@@ -582,7 +582,7 @@ const App = (() => {
   }
 
   function refreshCrafting() {
-    postJ('getCraftingData').then((r) => {
+    postJ('getCraftingTable').then((r) => {
       if (Array.isArray(r)) { const o = {}; r.forEach((x) => { if (x && x.name) o[x.name] = x; }); state.recipes = o; }
       else { state.recipes = r || {}; }
       renderCrafting();


### PR DESCRIPTION
## Summary
- add server callback `getCraftingTable` for crafting recipes
- expose NUI route on client and update web UI to use it

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `node -e "fetch('https://qb-jobcreator/getCraftingTable',{method:'POST'}).then(r=>r.text().then(t=>console.log('status',r.status,'body',t))).catch(e=>console.error('error',e.message));"` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ccd4707c832696fcf58c46eba578