### PR TITLE
Fix crafting progress bar reference

### DIFF
--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -1217,13 +1217,14 @@ const CraftUI = (() => {
       renderRecipes();
     }
     if (data.action === 'craftProgress') {
-      const prog = document.getElementById('craft-progress');
+      const prog = document.getElementById('craftCraftingBar');
       prog.classList.remove('hidden');
       const pct = data.progress || 0;
-      prog.querySelector('.bar').style.width = `${pct}%`;
+      document.getElementById('craftProgressInner').style.width = `${pct}%`;
     }
     if (data.action === 'craftResult') {
-      document.getElementById('craft-progress').classList.add('hidden');
+      document.getElementById('craftCraftingBar').classList.add('hidden');
+      document.getElementById('craftProgressInner').style.width = '0%';
       if (data.inventory) {
         inventory = data.inventory;
         renderInventory();


### PR DESCRIPTION
## Summary
- Correct craft progress bar handling by referencing existing `craftCraftingBar` and `craftProgressInner` elements
- Reset progress bar on craft completion to avoid stale state

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ce7dc74c8326a1fe9080b6ba55fb