### PR TITLE
fix(jobcreator): update craft UI element IDs

### DIFF
--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -1186,7 +1186,7 @@ const CraftUI = (() => {
     renderCategories();
     renderRecipes();
     renderInventory();
-    const searchInput = document.getElementById('craft-search');
+    const searchInput = document.getElementById('craftSearchInput');
     if (searchInput) {
       searchText = '';
       searchInput.value = '';
@@ -1197,12 +1197,12 @@ const CraftUI = (() => {
     }
     updateQueue();
     qTimer = setInterval(updateQueue, 5000);
-    document.getElementById('craft').classList.remove('hidden');
+    document.getElementById('craftApp').classList.remove('hidden');
     visible = true;
   }
 
   function close() {
-    document.getElementById('craft').classList.add('hidden');
+    document.getElementById('craftApp').classList.add('hidden');
     visible = false;
     if (qTimer) { clearInterval(qTimer); qTimer = null; }
   }


### PR DESCRIPTION
## Summary
- fix crafting panel by replacing obsolete `craft` and `craft-search` IDs

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b2d54a1e9c8326b51edbd378d580e4