### PR TITLE
Respect inventory image path convar for crafting UI

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -242,7 +242,9 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
   craftZone = zoneId
   uiOpen = true
   SetNuiFocus(true, true)
-  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = Config and Config.InventoryImagePath })
+  local imagePath = GetConvar('inventory:imagepath', Config and Config.InventoryImagePath or 'nui://ox_inventory/web/images/')
+  if imagePath:sub(-1) ~= '/' then imagePath = imagePath .. '/' end
+  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = imagePath })
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
     local function getItemCount(name)
       if GetResourceState('ox_inventory') == 'started' then

--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -2,7 +2,9 @@ Config = Config or {}
 
 -- Inventario y notificaciones
 Config.InventoryType = Config.InventoryType or 'qb'        -- 'qb', 'ox', 'tgiann', 'custom'
-Config.InventoryImagePath = Config.InventoryImagePath or 'nui://ox_inventory/web/images/'
+local imgPath = GetConvar('inventory:imagepath', Config.InventoryImagePath or 'nui://ox_inventory/web/images/')
+if imgPath:sub(-1) ~= '/' then imgPath = imgPath .. '/' end
+Config.InventoryImagePath = imgPath
 Config.NotifySystem = Config.NotifySystem or 'qb'          -- 'qb', 'ox', 'custom'
 Config.NotifyTitle = Config.NotifyTitle or 'Job Creator'
 
@@ -14,9 +16,8 @@ Config.General = Config.General or {
 }
 
 -- ===== INTERFACE CONFIGURATION / CONFIGURACIÓN DE INTERFAZ =====
-Config.Interface = Config.Interface or {
-  InventoryImagePath = 'nui://ox_inventory/web/images/', -- Ruta a imágenes del inventario / Path to inventory images
-}
+Config.Interface = Config.Interface or {}
+Config.Interface.InventoryImagePath = Config.Interface.InventoryImagePath or Config.InventoryImagePath
 
 -- ===== INVENTORY SYSTEM CONFIGURATION / CONFIGURACIÓN DEL SISTEMA DE INVENTARIO =====
 Config.InventorySystem = Config.InventorySystem or {


### PR DESCRIPTION
## Summary
- Fetch inventory image path from `inventory:imagepath` convar and ensure trailing slash before opening crafting UI
- Derive `Config.InventoryImagePath` from the same convar to keep configuration in sync

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b36be490588326a9fc499055b21d44