### PR TITLE
Filter craft recipes by job eligibility

### DIFF
--- a/invictus_craft/html/script.js
+++ b/invictus_craft/html/script.js
@@ -48,7 +48,7 @@ function renderCards(){
 
   for (const r of recipes){
     const card = document.createElement('div');
-    card.className = `card ${cardStateClass(r.status)} ${(r.lockedByJob || r.lockedBySkill) ? 'locked' : ''}`;
+    card.className = `card ${cardStateClass(r.status)} ${r.lockedBySkill ? 'locked' : ''}`;
     card.innerHTML = `
       <div class="img"><img src="${iconPath(r.item)}" onerror="this.style.opacity=.2"></div>
       <div class="title">${r.label || r.item}</div>
@@ -59,7 +59,7 @@ function renderCards(){
         <button class="small inc">+</button>
       </div>
       <button class="btn primary craftBtn">${App.locale.craft || 'CRAFT'}</button>
-      ${(r.lockedByJob || r.lockedBySkill) ? `<i class="fa-solid fa-lock lock" title="Locked"></i>` : ''}
+        ${r.lockedBySkill ? `<i class="fa-solid fa-lock lock" title="Locked"></i>` : ''}
     `;
     const qtyInput = card.querySelector('.qtyInput');
     card.querySelector('.dec').onclick = ()=> qtyInput.value = Math.max(1, Number(qtyInput.value)-1);
@@ -68,7 +68,7 @@ function renderCards(){
     card.querySelector('.img').onclick = openModal;
     card.querySelector('.title').onclick = openModal;
     card.querySelector('.craftBtn').onclick = ()=>{
-      if (r.lockedByJob || r.lockedBySkill) return;
+      if (r.lockedBySkill) return;
       fetchNui('craft', { item: r.item, amount: Number(qtyInput.value||1) });
     };
     grid.appendChild(card);

--- a/invictus_craft/server/main.lua
+++ b/invictus_craft/server/main.lua
@@ -101,21 +101,25 @@ local function buildStationPayload(src, stationId)
 
   for _, r in ipairs(Config.Recipes) do
     if r.category == st.category then
-      local jobLocked = r.requiredJob and not (type(r.requiredJob)=='table' and arrayIncludes(r.requiredJob, jobName) or r.requiredJob == jobName)
-      local skillLocked = not Utils.HasSkill(src, r.skillIID)
-      local status, mats = matsStatusForPlayer(src, r)
+      local jobAllowed = true
+      if r.requiredJob then
+        jobAllowed = type(r.requiredJob) == 'table' and arrayIncludes(r.requiredJob, jobName) or r.requiredJob == jobName
+      end
+      if jobAllowed then
+        local skillLocked = not Utils.HasSkill(src, r.skillIID)
+        local status, mats = matsStatusForPlayer(src, r)
 
-      recipes[#recipes+1] = {
-        item = r.item,
-        label = r.label or r.item,
-        time = r.time,
-        status = status,
-        materials = mats,
-        outputs = r.outputs or { { item = r.item, amount = 1 } },
-        lockedByJob = jobLocked,
-        lockedBySkill = skillLocked,
-        category = r.category
-      }
+        recipes[#recipes+1] = {
+          item = r.item,
+          label = r.label or r.item,
+          time = r.time,
+          status = status,
+          materials = mats,
+          outputs = r.outputs or { { item = r.item, amount = 1 } },
+          lockedBySkill = skillLocked,
+          category = r.category
+        }
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Skip recipes the player can't craft due to job restrictions when building station payloads
- Simplify NUI to only handle skill-based locks, sending only authorized recipes to the UI

## Testing
- `luacheck invictus_craft/server/main.lua` *(fails: command not found)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b376e660208326a2cab4aeba401568