### PR TITLE
Fix crafting image handling

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -291,7 +291,7 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
           materials = mats,
           outputs = { { item = recipe.output.item, amount = recipe.output.amount } },
           status = status,
-          image = info.image,
+          image = info.image or (recipe.output.item .. '.png'),
           lockedByJob = recipe.lockedByJob
         }
       end

--- a/qb-jobcreator/web/crafting.css
+++ b/qb-jobcreator/web/crafting.css
@@ -32,7 +32,7 @@ body { margin: 0; font-family: Inter, system-ui, Arial; background: transparent;
   display: grid; grid-template-rows: auto auto auto; gap: 6px;
 }
 .craft-app .card .img { height: 96px; display: grid; place-items: center; }
-.craft-app .card .img img { max-height: 96px; max-width: 100px; filter: drop-shadow(0 0 10px rgba(0,0,0,.2)); }
+.craft-app .card .img img { width: 96px; height: 96px; object-fit: contain; filter: drop-shadow(0 0 10px rgba(0,0,0,.2)); }
 
 .craft-app .card .title { text-align: center; font-weight: 600; }
 .craft-app .card .hint { font-size: 12px; opacity: .7; text-align: center; }

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -35,7 +35,11 @@ function renderAll(){
   setupSearch();
 }
 
-function iconPath(img){ return `${CraftApp.images}${img}`; }
+function iconPath(img){
+  if(!img) return `${CraftApp.images}placeholder.png`;
+  if(!img.includes('.')) img = `${img}.png`;
+  return `${CraftApp.images}${img}`;
+}
 function cardStateClass(status){ return status === 'all' ? 'state-all' : status === 'some' ? 'state-some' : 'state-none'; }
 
 function renderCards(){
@@ -50,9 +54,9 @@ function renderCards(){
     const card = document.createElement('div');
     card.className = `card ${cardStateClass(r.status)} ${(r.lockedByJob || r.lockedBySkill) ? 'locked' : ''}`;
     const imgSrc = iconPath(r.image);
-    const errSrc = iconPath('placeholder.png');
+    const errSrc = iconPath('placeholder');
     card.innerHTML = `
-      <div class="img"><img src="${imgSrc}" onerror="this.src='${errSrc}'"></div>
+      <div class="img"><img src="${imgSrc}" width="96" height="96" loading="lazy" onerror="this.src='${errSrc}'"></div>
       <div class="title">${r.label || r.item}</div>
       <div class="hint">${CraftApp.locale.click_to_info || 'Click to view information'}</div>
       <div class="qtyRow">
@@ -85,10 +89,10 @@ function renderSidebars(){
   for (const it of q){
     const row = document.createElement('div');
     row.className='queueItem';
-    const imgSrc = iconPath(`${it.item}.png`);
-    const errSrc = iconPath('placeholder.png');
+    const imgSrc = iconPath(it.item);
+    const errSrc = iconPath('placeholder');
     row.innerHTML = `
-      <img src="${imgSrc}" width="32" height="32" onerror="this.src='${errSrc}'">
+      <img src="${imgSrc}" width="32" height="32" loading="lazy" onerror="this.src='${errSrc}'">
       <div>
         <div><b>${it.label}</b></div>
         <div class="badge">${it.amount}x</div>
@@ -102,10 +106,10 @@ function renderSidebars(){
   for (const it of ready){
     const row = document.createElement('div');
     row.className='collectItem';
-    const imgSrc = iconPath(`${(it.outputs?.[0]?.item || 'unknown')}.png`);
-    const errSrc = iconPath('placeholder.png');
+    const imgSrc = iconPath(it.outputs?.[0]?.item || 'unknown');
+    const errSrc = iconPath('placeholder');
     row.innerHTML = `
-      <img src="${imgSrc}" width="32" height="32" onerror="this.src='${errSrc}'">
+      <img src="${imgSrc}" width="32" height="32" loading="lazy" onerror="this.src='${errSrc}'">
       <div>
         <div><b>${it.label}</b></div>
         <div class="badge">${new Date(it.timestamp*1000).toLocaleTimeString()}</div>
@@ -129,10 +133,10 @@ function showModal(r){
   for (const m of r.materials||[]){
     const row = document.createElement('div');
     row.className='mat';
-    const imgSrc = iconPath(`${m.item}.png`);
-    const errSrc = iconPath('placeholder.png');
+    const imgSrc = iconPath(m.item);
+    const errSrc = iconPath('placeholder');
     row.innerHTML = `
-      <img src="${imgSrc}" width="36" height="36" onerror="this.src='${errSrc}'">
+      <img src="${imgSrc}" width="36" height="36" loading="lazy" onerror="this.src='${errSrc}'">
       <div>${m.item}</div>
       <div class="need">${m.have||0}/${m.need}${m.noConsume?' (tool)':''}</div>
     `;
@@ -142,10 +146,10 @@ function showModal(r){
   for (const o of r.outputs||[]){
     const row = document.createElement('div');
     row.className='out';
-    const imgSrc = iconPath(`${o.item}.png`);
-    const errSrc = iconPath('placeholder.png');
+    const imgSrc = iconPath(o.item);
+    const errSrc = iconPath('placeholder');
     row.innerHTML = `
-      <img src="${imgSrc}" width="36" height="36" onerror="this.src='${errSrc}'">
+      <img src="${imgSrc}" width="36" height="36" loading="lazy" onerror="this.src='${errSrc}'">
       <div>${o.item}</div>
       <div class="need">x${o.amount}</div>
     `;


### PR DESCRIPTION
## Summary
- Ensure fallback icon in client crafting data
- Improve NUI icon path generation and lazy load images
- Set fixed card image dimensions to prevent flicker

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b37fdb2c348326a0a0544989d15738