### PR TITLE
feat: add theme customization for crafting

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -22,6 +22,12 @@ RegisterNetEvent('qb-jobcreator:client:syncAll', function(jobs, zones)
   Jobs, Zones = jobs or {}, zones or {}
 end)
 
+local function findZoneById(id)
+  for _, z in ipairs(Zones or {}) do
+    if z.id == id then return z end
+  end
+end
+
 local function ForceClose()
   SetNuiFocus(false, false)
   SetNuiFocusKeepInput(false)
@@ -244,7 +250,9 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
   SetNuiFocus(true, true)
   local imagePath = GetConvar('inventory:imagepath', Config and Config.InventoryImagePath or 'nui://ox_inventory/web/images/')
   if imagePath:sub(-1) ~= '/' then imagePath = imagePath .. '/' end
-  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = imagePath })
+  local zone = findZoneById(zoneId)
+  local theme = zone and zone.data and zone.data.theme or nil
+  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = imagePath, theme = theme })
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
     local function getItemCount(name)
       if GetResourceState('ox_inventory') == 'started' then

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -176,7 +176,23 @@ local function LoadAll()
   end
   for _, z in ipairs(DB.GetZones()) do
     local data = json.decode(z.data or '{}') or {}
-    if z.ztype == 'shop' then data.items = SanitizeShopItems(data.items) end
+    if z.ztype == 'shop' then data.items = SanitizeShopItems(data.items)
+    elseif z.ztype == 'crafting' then
+      data.allowedCategories = SanitizeCategoryList(data.allowedCategories)
+      data.recipes = SanitizeRecipeList(data.recipes)
+      data.category = type(data.category) == 'string' and data.category or nil
+      if type(data.job) ~= 'string' and type(data.job) ~= 'table' then data.job = nil end
+      data.icon = type(data.icon) == 'string' and data.icon or nil
+      if type(data.theme) == 'table' then
+        data.theme = {
+          colorPrimario = type(data.theme.colorPrimario) == 'string' and data.theme.colorPrimario or nil,
+          colorSecundario = type(data.theme.colorSecundario) == 'string' and data.theme.colorSecundario or nil,
+          titulo = type(data.theme.titulo) == 'string' and data.theme.titulo or nil,
+        }
+      else
+        data.theme = nil
+      end
+    end
     local coords = json.decode(z.coords or '{}') or {}
     Runtime.Zones[#Runtime.Zones+1] = {
       id = z.id, job = z.job, ztype = z.ztype, label = z.label,
@@ -532,6 +548,16 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
       zone.data.job = nil
     end
     zone.data.icon = type(zone.data.icon) == 'string' and zone.data.icon or nil
+    if type(zone.data.theme) == 'table' then
+      local th = zone.data.theme
+      zone.data.theme = {
+        colorPrimario = type(th.colorPrimario) == 'string' and th.colorPrimario or nil,
+        colorSecundario = type(th.colorSecundario) == 'string' and th.colorSecundario or nil,
+        titulo = type(th.titulo) == 'string' and th.titulo or nil,
+      }
+    else
+      zone.data.theme = nil
+    end
   end
   local id = MySQL.insert.await('INSERT INTO jobcreator_zones (job,ztype,label,coords,radius,data) VALUES (?,?,?,?,?,?)',
     { zone.job, zone.ztype, zone.label or zone.ztype, json.encode(zone.coords), zone.radius or 2.0, json.encode(zone.data or {}) })
@@ -554,6 +580,15 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
       nz.data.job = nil
     end
     nz.data.icon = type(nz.data.icon) == 'string' and nz.data.icon or nil
+    if type(nz.data.theme) == 'table' then
+      nz.data.theme = {
+        colorPrimario = type(nz.data.theme.colorPrimario) == 'string' and nz.data.theme.colorPrimario or nil,
+        colorSecundario = type(nz.data.theme.colorSecundario) == 'string' and nz.data.theme.colorSecundario or nil,
+        titulo = type(nz.data.theme.titulo) == 'string' and nz.data.theme.titulo or nil,
+      }
+    else
+      nz.data.theme = nil
+    end
   end
   Runtime.Zones[#Runtime.Zones+1] = nz
   TriggerClientEvent('qb-jobcreator:client:rebuildZones', -1, Runtime.Zones)
@@ -790,6 +825,15 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
         data.job = nil
       end
       data.icon = type(data.icon) == 'string' and data.icon or nil
+      if type(data.theme) == 'table' then
+        data.theme = {
+          colorPrimario = type(data.theme.colorPrimario) == 'string' and data.theme.colorPrimario or nil,
+          colorSecundario = type(data.theme.colorSecundario) == 'string' and data.theme.colorSecundario or nil,
+          titulo = type(data.theme.titulo) == 'string' and data.theme.titulo or nil,
+        }
+      else
+        data.theme = nil
+      end
     end
     data.clearArea = data.clearArea and true or false
     if data.clearRadius ~= nil then data.clearRadius = tonumber(data.clearRadius) or Config.Zone.ClearRadius end
@@ -809,6 +853,15 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
           nd.category = type(nd.category) == 'string' and nd.category or nil
           if type(nd.job) ~= 'string' and type(nd.job) ~= 'table' then nd.job = nil end
           nd.icon = type(nd.icon) == 'string' and nd.icon or nil
+          if type(nd.theme) == 'table' then
+            nd.theme = {
+              colorPrimario = type(nd.theme.colorPrimario) == 'string' and nd.theme.colorPrimario or nil,
+              colorSecundario = type(nd.theme.colorSecundario) == 'string' and nd.theme.colorSecundario or nil,
+              titulo = type(nd.theme.titulo) == 'string' and nd.theme.titulo or nil,
+            }
+          else
+            nd.theme = nil
+          end
         end
         Runtime.Zones[idx] = {
           id = r.id, job = r.job, ztype = r.ztype, label = r.label,

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -740,6 +740,10 @@ const App = (() => {
                             else if (jobStr !== '') data.job = jobStr;
                             const icon = document.getElementById('zicon')?.value || '';
                             if (icon) data.icon = icon;
+                            const colorPrimario = document.getElementById('zcpri')?.value || '';
+                            const colorSecundario = document.getElementById('zcsec')?.value || '';
+                            const titulo = document.getElementById('zctitle')?.value || '';
+                            data.theme = { colorPrimario, colorSecundario, titulo };
                            }
         if (t === 'cloakroom') data.mode = (document.getElementById('zckmode')?.value || 'illenium').toLowerCase();
         if (t === 'shop')  { data.items = collectShopItems(); }
@@ -800,10 +804,12 @@ const App = (() => {
           const catOpts = catList.map((c) => `<option value="${c}" ${(d.allowedCategories||[]).includes(c)?'selected':''}>${c}</option>`).join('');
           const recOpts = Object.keys(state.recipes || {}).map((r) => `<option value="${r}" ${(d.recipes||[]).includes(r)?'selected':''}>${r}</option>`).join('');
           const jobVal = Array.isArray(d.job) ? d.job.join(',') : (d.job || '');
+          const th = d.theme || {};
           box.innerHTML = row(`<div style="flex:1"><label>Categorías</label><select id="zcats" class="input" multiple>${catOpts}</select></div>`) +
                         row(`<div style="flex:1"><label>Recetas</label><select id="zrecipes" class="input" multiple>${recOpts}</select></div>`) +
                         row(inp('zcateg','Categoría','food', d.category || '') + inp('zjob','Job Lock','', jobVal)) +
-                        row(inp('zicon','Icono','fa-solid fa-hammer', d.icon || ''));
+                        row(inp('zicon','Icono','fa-solid fa-hammer', d.icon || '')) +
+                        row(inp('zcpri','Color Primario','#53a88c', th.colorPrimario || '') + inp('zcsec','Color Secundario','#2f7a62', th.colorSecundario || '') + inp('zctitle','Título','', th.titulo || ''));
         } else if (t === 'cloakroom') {
           box.innerHTML = row(inp('zckmode','Modo','illenium / qb-clothing', d.mode || ''));
         } else if (t === 'shop') {
@@ -872,6 +878,10 @@ const App = (() => {
             else if (jobStr !== '') data.job = jobStr;
             const icon = document.getElementById('zicon')?.value || '';
             if (icon) data.icon = icon;
+            const colorPrimario = document.getElementById('zcpri')?.value || '';
+            const colorSecundario = document.getElementById('zcsec')?.value || '';
+            const titulo = document.getElementById('zctitle')?.value || '';
+            data.theme = { colorPrimario, colorSecundario, titulo };
           }
           if (t === 'cloakroom') data.mode = (document.getElementById('zckmode')?.value || 'illenium').toLowerCase();
           if (t === 'shop')  { data.items = collectShopItems(); }
@@ -936,7 +946,8 @@ const App = (() => {
         box.innerHTML = row(`<div style="flex:1"><label>Categorías</label><select id="zcats" class="input" multiple>${catOpts}</select></div>`) +
                         row(`<div style="flex:1"><label>Recetas</label><select id="zrecipes" class="input" multiple>${recOpts}</select></div>`) +
                         row(inp('zcateg','Categoría','food') + inp('zjob','Job Lock','')) +
-                        row(inp('zicon','Icono','fa-solid fa-hammer'));
+                        row(inp('zicon','Icono','fa-solid fa-hammer')) +
+                        row(inp('zcpri','Color Primario','#53a88c') + inp('zcsec','Color Secundario','#2f7a62') + inp('zctitle','Título',''));
       } else if (t === 'cloakroom') {
         box.innerHTML = row(inp('zckmode','Modo','illenium / qb-clothing'));
       } else if (t === 'shop') {

--- a/qb-jobcreator/web/crafting.css
+++ b/qb-jobcreator/web/crafting.css
@@ -1,34 +1,45 @@
 * { box-sizing: border-box; user-select: none; }
 body { margin: 0; font-family: Inter, system-ui, Arial; background: transparent; }
 
+:root {
+  --bg: rgba(7,20,18,.92);
+  --accent: #53a88c;
+  --accent-alt: #2f7a62;
+  --text: #e8f0ef;
+  --muted: #cfe3e0;
+  --panel: #0e1917;
+  --panel-alt: #0d1715;
+  --danger: #512e2e;
+}
+
 .hidden { display: none !important; }
 
 .craft-app {
-  position: absolute; inset: 5% 5%; background: rgba(7,20,18,.92);
+  position: absolute; inset: 5% 5%; background: var(--bg);
   border: 1px solid rgba(255,255,255,.08); border-radius: 12px;
-  color: #e8f0ef; display: grid; grid-template-columns: 1fr 320px; grid-template-rows: auto auto 1fr;
+  color: var(--text); display: grid; grid-template-columns: 1fr 320px; grid-template-rows: auto auto 1fr;
   gap: 12px; padding: 16px; overflow: hidden;
 }
 
 .craft-app .header { grid-column: 1 / span 2; display: flex; align-items: center; justify-content: space-between; }
 .craft-app .title { font-size: 24px; letter-spacing: .5px; display: flex; align-items: center; gap: 10px; }
-.craft-app .tag { font-size: 12px; background: #1e2f2c; padding: 4px 8px; border-radius: 999px; border: 1px solid rgba(255,255,255,.08); }
+.craft-app .tag { font-size: 12px; background: var(--accent-alt); padding: 4px 8px; border-radius: 999px; border: 1px solid rgba(255,255,255,.08); }
 
 .craft-app .search { position: relative; }
 .craft-app .search input {
-  background: #0d1715; color: #cfe3e0; border: 1px solid rgba(255,255,255,.1);
+  background: var(--panel-alt); color: var(--muted); border: 1px solid rgba(255,255,255,.1);
   padding: 10px 34px 10px 12px; border-radius: 8px; width: 260px; outline: none;
 }
 .craft-app .search i { position: absolute; right: 10px; top: 10px; opacity: .7; }
 
 .craft-app .statusBar { grid-column: 1 / span 2; display: grid; grid-template-columns: 1fr 140px; gap: 10px; align-items: center; }
-.craft-app .progress { height: 18px; background: #0f1716; border: 1px solid rgba(255,255,255,.08); border-radius: 8px; overflow: hidden; }
-.craft-app .progress > div { height: 100%; width: 0%; background: linear-gradient(90deg,#8dd4b4,#53a88c); transition: width .2s; }
+.craft-app .progress { height: 18px; background: var(--panel-alt); border: 1px solid rgba(255,255,255,.08); border-radius: 8px; overflow: hidden; }
+.craft-app .progress > div { height: 100%; width: 0%; background: linear-gradient(90deg,var(--accent),var(--accent-alt)); transition: width .2s; }
 .craft-app .time { font-size: 12px; opacity: .8; text-align: right; }
 
 .craft-app .grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding-bottom: 12px; overflow: auto; }
 .craft-app .card {
-  background: #0e1917; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px;
+  background: var(--panel); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 12px;
   display: grid; grid-template-rows: auto auto auto; gap: 6px;
 }
 .craft-app .card .img { height: 96px; display: grid; place-items: center; }
@@ -37,7 +48,7 @@ body { margin: 0; font-family: Inter, system-ui, Arial; background: transparent;
 .craft-app .card .title { text-align: center; font-weight: 600; }
 .craft-app .card .hint { font-size: 12px; opacity: .7; text-align: center; }
 .craft-app .card .qtyRow { display: grid; grid-template-columns: 32px 1fr 32px; gap: 6px; align-items: center; }
-.craft-app .small { height: 32px; background: #142321; border: 1px solid rgba(255,255,255,.08); color: #cfe3e0; border-radius: 8px; }
+.craft-app .small { height: 32px; background: var(--panel); border: 1px solid rgba(255,255,255,.08); color: var(--muted); border-radius: 8px; }
 .craft-app .card .btn { margin-top: 6px; }
 
 .craft-app .card.locked { filter: grayscale(100%); opacity: .65; }
@@ -45,34 +56,34 @@ body { margin: 0; font-family: Inter, system-ui, Arial; background: transparent;
 
 .craft-app .btn {
   width: 100%; padding: 10px 12px; border-radius: 8px; border: 1px solid rgba(255,255,255,.12);
-  background: #173430; color: #e8f0ef; font-weight: 700; cursor: pointer;
+  background: var(--accent-alt); color: var(--text); font-weight: 700; cursor: pointer;
 }
-.craft-app .btn.primary { background: linear-gradient(90deg,#53a88c,#2f7a62); }
-.craft-app .btn.danger { background: #512e2e; }
+.craft-app .btn.primary { background: linear-gradient(90deg,var(--accent),var(--accent-alt)); }
+.craft-app .btn.danger { background: var(--danger); }
 
 .craft-app .sidebar { overflow: auto; display: grid; grid-auto-rows: min-content; gap: 12px; }
-.craft-app .panel { background:#0e1917; border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 10px; }
+.craft-app .panel { background:var(--panel); border: 1px solid rgba(255,255,255,.08); border-radius: 12px; padding: 10px; }
 .craft-app .panel-title { font-weight: 700; margin-bottom: 8px; }
 .craft-app .panel-body { display: grid; gap: 6px; }
 .craft-app .panel-body.empty { opacity: .7; font-size: 13px; }
 
 .craft-app .queueItem, .craft-app .collectItem {
   display: grid; grid-template-columns: 36px 1fr auto; align-items: center; gap: 8px;
-  padding: 8px; border: 1px solid rgba(255,255,255,.06); border-radius: 10px; background: #0c1513;
+  padding: 8px; border: 1px solid rgba(255,255,255,.06); border-radius: 10px; background: var(--panel-alt);
 }
-.craft-app .badge { background: #112320; padding: 2px 6px; border-radius: 6px; font-size: 11px; }
+.craft-app .badge { background: var(--accent-alt); padding: 2px 6px; border-radius: 6px; font-size: 11px; }
 
 .craft-modal { position: fixed; inset: 0; background: rgba(0,0,0,.45); display: grid; place-items: center; }
-.craft-modal .modal-inner { width: 540px; background:#0d1816; border:1px solid rgba(255,255,255,.1); border-radius: 12px; overflow: hidden; }
+.craft-modal .modal-inner { width: 540px; background:var(--panel-alt); border:1px solid rgba(255,255,255,.1); border-radius: 12px; overflow: hidden; }
 .craft-modal .modal-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid rgba(255,255,255,.08); }
-.craft-modal .xbtn { background: transparent; border: 0; color: #e8f0ef; font-size: 18px; cursor: pointer; }
+.craft-modal .xbtn { background: transparent; border: 0; color: var(--text); font-size: 18px; cursor: pointer; }
 
 .craft-modal .modal-body { padding: 12px 16px; display: grid; gap: 10px; }
 .craft-app .mats, .craft-app .outs { display: grid; gap: 8px; }
 .craft-app .mat, .craft-app .out { display: grid; grid-template-columns: 40px 1fr auto; gap: 8px; align-items: center; }
 .craft-app .mats .need { font-size: 12px; opacity: .8; }
 .craft-app .qty { display: grid; grid-template-columns: 48px 1fr 48px; gap: 8px; }
-.craft-app .qty input { background:#0f1a18; border:1px solid rgba(255,255,255,.08); color:#cfe3e0; padding:8px; border-radius:8px; text-align:center; }
+.craft-app .qty input { background:var(--panel-alt); border:1px solid rgba(255,255,255,.08); color:var(--muted); padding:8px; border-radius:8px; text-align:center; }
 
 .craft-app .state-all { outline: 2px solid #45d483; }
 .craft-app .state-some { outline: 2px solid #d1b73f; }

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -13,7 +13,10 @@ window.addEventListener('message', (e) => {
   if (msg.action === 'openCraft') {
     CraftApp.locale = msg.locale || {};
     CraftApp.images = msg.images || CraftApp.images;
-    $('#craftTitleText').innerText = CraftApp.locale.ui_title || 'KITCHEN';
+    const th = msg.theme || {};
+    if (th.colorPrimario) document.documentElement.style.setProperty('--bg', th.colorPrimario);
+    if (th.colorSecundario) document.documentElement.style.setProperty('--accent', th.colorSecundario);
+    $('#craftTitleText').innerText = th.titulo || CraftApp.locale.ui_title || 'KITCHEN';
     $('#craftCategoryTag').innerText = CraftApp.locale.ui_tab_food || 'FOOD';
     $('#craftPendingTitle').innerText = CraftApp.locale.queue_pending || 'PENDING ITEMS';
     $('#craftCollectTitle').innerText = CraftApp.locale.queue_collect || 'ITEMS TO COLLECT';


### PR DESCRIPTION
## Summary
- expose CSS variables for crafting interface and apply them based on zone theme
- allow job creator to configure crafting zone colors and title
- persist crafting theme settings server-side and send to NUI on open

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3812304008326a4bcd636564811d8