### PR TITLE
Handle fallback category in jobcreator crafting zones

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -461,6 +461,10 @@ local function CollectCraftingData(src, zoneId)
     local list = {}
     local data = zone.data or {}
     local cats = data.allowedCategories
+    local recs = data.recipes
+    if (not cats or #cats == 0) and (not recs or #recs == 0) and data.category then
+      cats = { data.category }
+    end
     if cats and #cats > 0 then
       local set = {}
       for _, c in ipairs(cats) do set[c] = true end
@@ -475,7 +479,7 @@ local function CollectCraftingData(src, zoneId)
         end
       end
     else
-      for _, name in ipairs(data.recipes or {}) do
+      for _, name in ipairs(recs or {}) do
         local r = Config.CraftingRecipes[name]
         if r then
           local allow, locked = checkRecipeJob(r.job, zone.job, jobName)

--- a/qb-jobcreator/tests/collect_crafting_data_category_test.lua
+++ b/qb-jobcreator/tests/collect_crafting_data_category_test.lua
@@ -1,0 +1,49 @@
+local file = assert(io.open("qb-jobcreator/server/main.lua", "r"))
+local src = file:read("*a")
+file:close()
+
+local body = src:match("local function CollectCraftingData%([^%)]*%)(.-)\nend")
+assert(body, "CollectCraftingData function not found")
+local collect = load("return function(src, zoneId)" .. body .. "\nend")()
+
+QBCore = { Functions = { GetPlayer = function(_) return { PlayerData = { job = { name = 'testjob' } } } end }}
+
+checkRecipeJob = function(recipeJob, zoneJob, playerJob)
+  return true, false
+end
+
+local testZone = {
+  id = 1,
+  job = 'testjob',
+  data = {
+    category = 'food',
+    allowedCategories = {},
+    recipes = {}
+  }
+}
+
+findZoneById = function(id)
+  if id == testZone.id then return testZone end
+end
+
+playerInJobZone = function(src, zone, ztype)
+  assert(zone == testZone and ztype == 'crafting')
+  return true, zone
+end
+
+Config = {
+  LockedItemsDisplay = { showLocked = false },
+  CraftingRecipes = {
+    applepie = { category = 'food', inputs = {}, time = 1, output = {} },
+    salad = { category = 'food', inputs = {}, time = 1, output = {} },
+    wrench = { category = 'tools', inputs = {}, time = 1, output = {} }
+  }
+}
+
+local result = collect(1, 1)
+assert(#result == 2, "Expected 2 recipes, got " .. #result)
+for _, r in ipairs(result) do
+  assert(r.category == 'food', 'Unexpected category '..tostring(r.category))
+end
+
+print('CollectCraftingData category test passed')


### PR DESCRIPTION
## Summary
- use `zone.data.category` as a fallback allowed category when no categories or recipes are specified
- add unit test for `CollectCraftingData` category fallback

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua && lua qb-jobcreator/tests/collect_crafting_data_category_test.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b38fecfa9c83268ec91109f0fb61ef