### PR TITLE
feat: expose crafting title and category

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -252,7 +252,16 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
   if imagePath:sub(-1) ~= '/' then imagePath = imagePath .. '/' end
   local zone = findZoneById(zoneId)
   local theme = zone and zone.data and zone.data.theme or nil
-  SendNUIMessage({ action = 'openCraft', locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {}, images = imagePath, theme = theme })
+  local title = (theme and theme.titulo) or (zone and zone.label) or nil
+  local category = zone and zone.data and zone.data.category or nil
+  SendNUIMessage({
+    action = 'openCraft',
+    locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {},
+    images = imagePath,
+    theme = theme,
+    title = title,
+    category = category
+  })
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
     local function getItemCount(name)
       if GetResourceState('ox_inventory') == 'started' then

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -14,10 +14,17 @@ window.addEventListener('message', (e) => {
     CraftApp.locale = msg.locale || {};
     CraftApp.images = msg.images || CraftApp.images;
     const th = msg.theme || {};
-    if (th.colorPrimario) document.documentElement.style.setProperty('--bg', th.colorPrimario);
-    if (th.colorSecundario) document.documentElement.style.setProperty('--accent', th.colorSecundario);
-    $('#craftTitleText').innerText = th.titulo || CraftApp.locale.ui_title || 'KITCHEN';
-    $('#craftCategoryTag').innerText = CraftApp.locale.ui_tab_food || 'FOOD';
+    const varMap = {
+      colorPrimario: '--bg',
+      colorPrimarioAlt: '--bg-alt',
+      colorSecundario: '--accent',
+      colorSecundarioAlt: '--accent-alt'
+    };
+    Object.entries(varMap).forEach(([k, v]) => {
+      if (th[k]) document.documentElement.style.setProperty(v, th[k]);
+    });
+    $('#craftTitleText').innerText = msg.title || th.titulo || CraftApp.locale.ui_title || 'KITCHEN';
+    $('#craftCategoryTag').innerText = msg.category || CraftApp.locale.ui_tab_food || 'FOOD';
     $('#craftPendingTitle').innerText = CraftApp.locale.queue_pending || 'PENDING ITEMS';
     $('#craftCollectTitle').innerText = CraftApp.locale.queue_collect || 'ITEMS TO COLLECT';
     $('#craftBtnLeaveAll').innerText = CraftApp.locale.leave_all || 'LEAVE ALL QUEUES';


### PR DESCRIPTION
## Summary
- send zone label and category to crafting NUI
- apply extra theme variables and use provided title/category in crafting UI

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_category_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b39190036c832690423729bbde0b00