### PR TITLE
Remove zone category field in job creator

### DIFF
--- a/qb-jobcreator/README.md
+++ b/qb-jobcreator/README.md
@@ -43,6 +43,9 @@ En la tienda del herrero añade `metal_ore` con el precio y stock deseado.  Los 
 recetas permitidas.  Cada receta requiere `inputs`, `time` y `output`, y puede
 incluir opcionalmente `blueprint`, `skill` y `successChance`.
 
+En estas zonas, las recetas mostradas se filtran solo mediante `allowedCategories` o
+`recipes`. El campo `category` dentro de la zona ha sido eliminado.
+
 Se soportan planos opcionales y bonificaciones por habilidad mediante `qb-skillz`;
 el servidor verifica los materiales y entrega el resultado al jugador cuando el
 proceso finaliza.

--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -253,14 +253,12 @@ RegisterNetEvent('qb-jobcreator:client:openCrafting', function(zoneId)
   local zone = findZoneById(zoneId)
   local theme = zone and zone.data and zone.data.theme or nil
   local title = (theme and theme.titulo) or (zone and zone.label) or nil
-  local category = zone and zone.data and zone.data.category or nil
   SendNUIMessage({
     action = 'openCraft',
     locale = Locales and (Config and Locales[Config.language or Config.Language] or {}) or {},
     images = imagePath,
     theme = theme,
-    title = title,
-    category = category
+    title = title
   })
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingData', function(recipes)
     local function getItemCount(name)

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -180,7 +180,6 @@ local function LoadAll()
     elseif z.ztype == 'crafting' then
       data.allowedCategories = SanitizeCategoryList(data.allowedCategories)
       data.recipes = SanitizeRecipeList(data.recipes)
-      data.category = type(data.category) == 'string' and data.category or nil
       if type(data.job) ~= 'string' and type(data.job) ~= 'table' then data.job = nil end
       data.icon = type(data.icon) == 'string' and data.icon or nil
       if type(data.theme) == 'table' then
@@ -462,9 +461,6 @@ local function CollectCraftingData(src, zoneId)
     local data = zone.data or {}
     local cats = data.allowedCategories
     local recs = data.recipes
-    if (not cats or #cats == 0) and (not recs or #recs == 0) and data.category then
-      cats = { data.category }
-    end
     if cats and #cats > 0 then
       local set = {}
       for _, c in ipairs(cats) do set[c] = true end
@@ -541,7 +537,6 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
   elseif zone.ztype == 'crafting' then
     zone.data.allowedCategories = SanitizeCategoryList(zone.data.allowedCategories)
     zone.data.recipes = SanitizeRecipeList(zone.data.recipes)
-    zone.data.category = type(zone.data.category) == 'string' and zone.data.category or nil
     if type(zone.data.job) == 'string' then
       zone.data.job = zone.data.job ~= '' and zone.data.job or nil
     elseif type(zone.data.job) == 'table' then
@@ -579,7 +574,6 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
   elseif nz.ztype == 'crafting' then
     nz.data.allowedCategories = SanitizeCategoryList(nz.data.allowedCategories)
     nz.data.recipes = SanitizeRecipeList(nz.data.recipes)
-    nz.data.category = type(nz.data.category) == 'string' and nz.data.category or nil
     if type(nz.data.job) ~= 'string' and type(nz.data.job) ~= 'table' then
       nz.data.job = nil
     end
@@ -818,7 +812,6 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
     elseif ztype == 'crafting' then
       data.allowedCategories = SanitizeCategoryList(data.allowedCategories)
       data.recipes = SanitizeRecipeList(data.recipes)
-      data.category = type(data.category) == 'string' and data.category or nil
       if type(data.job) == 'string' then
         data.job = data.job ~= '' and data.job or nil
       elseif type(data.job) == 'table' then
@@ -854,7 +847,6 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
         elseif ztype == 'crafting' then
           nd.allowedCategories = SanitizeCategoryList(nd.allowedCategories)
           nd.recipes = SanitizeRecipeList(nd.recipes)
-          nd.category = type(nd.category) == 'string' and nd.category or nil
           if type(nd.job) ~= 'string' and type(nd.job) ~= 'table' then nd.job = nil end
           nd.icon = type(nd.icon) == 'string' and nd.icon or nil
           if type(nd.theme) == 'table' then

--- a/qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua
+++ b/qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua
@@ -16,8 +16,7 @@ local testZone = {
   id = 1,
   job = 'testjob',
   data = {
-    category = 'food',
-    allowedCategories = {},
+    allowedCategories = { 'food' },
     recipes = {}
   }
 }
@@ -46,4 +45,4 @@ for _, r in ipairs(result) do
   assert(r.category == 'food', 'Unexpected category '..tostring(r.category))
 end
 
-print('CollectCraftingData category test passed')
+print('CollectCraftingData allowedCategories test passed')

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -734,7 +734,6 @@ const App = (() => {
                             const cats = Array.from(document.getElementById('zcats')?.selectedOptions || []).map((o) => o.value);
                             const recs = Array.from(document.getElementById('zrecipes')?.selectedOptions || []).map((o) => o.value);
                             if (cats.length > 0) data.allowedCategories = cats; else data.recipes = recs;
-                            data.category = document.getElementById('zcateg')?.value || '';
                             const jobStr = document.getElementById('zjob')?.value || '';
                             if (jobStr.includes(',')) data.job = jobStr.split(',').map(s=>s.trim()).filter(s=>s);
                             else if (jobStr !== '') data.job = jobStr;
@@ -807,7 +806,7 @@ const App = (() => {
           const th = d.theme || {};
           box.innerHTML = row(`<div style="flex:1"><label>Categorías</label><select id="zcats" class="input" multiple>${catOpts}</select></div>`) +
                         row(`<div style="flex:1"><label>Recetas</label><select id="zrecipes" class="input" multiple>${recOpts}</select></div>`) +
-                        row(inp('zcateg','Categoría','food', d.category || '') + inp('zjob','Job Lock','', jobVal)) +
+                        row(inp('zjob','Job Lock','', jobVal)) +
                         row(inp('zicon','Icono','fa-solid fa-hammer', d.icon || '')) +
                         row(inp('zcpri','Color Primario','#53a88c', th.colorPrimario || '') + inp('zcsec','Color Secundario','#2f7a62', th.colorSecundario || '') + inp('zctitle','Título','', th.titulo || ''));
         } else if (t === 'cloakroom') {
@@ -872,7 +871,6 @@ const App = (() => {
             const cats = Array.from(document.getElementById('zcats')?.selectedOptions || []).map((o) => o.value);
             const recs = Array.from(document.getElementById('zrecipes')?.selectedOptions || []).map((o) => o.value);
             if (cats.length > 0) data.allowedCategories = cats; else data.recipes = recs;
-            data.category = document.getElementById('zcateg')?.value || '';
             const jobStr = document.getElementById('zjob')?.value || '';
             if (jobStr.includes(',')) data.job = jobStr.split(',').map(s=>s.trim()).filter(s=>s);
             else if (jobStr !== '') data.job = jobStr;
@@ -943,9 +941,9 @@ const App = (() => {
         const catList = Array.from(new Set(Object.values(state.recipes || {}).map(r => r.category || 'General')));
         const catOpts = catList.map((c) => `<option value="${c}">${c}</option>`).join('');
         const recOpts = Object.keys(state.recipes || {}).map((r) => `<option>${r}</option>`).join('');
-        box.innerHTML = row(`<div style="flex:1"><label>Categorías</label><select id="zcats" class="input" multiple>${catOpts}</select></div>`) +
-                        row(`<div style="flex:1"><label>Recetas</label><select id="zrecipes" class="input" multiple>${recOpts}</select></div>`) +
-                        row(inp('zcateg','Categoría','food') + inp('zjob','Job Lock','')) +
+        box.innerHTML = row(`<div style=\"flex:1\"><label>Categorías</label><select id=\"zcats\" class=\"input\" multiple>${catOpts}</select></div>`) +
+                        row(`<div style=\"flex:1\"><label>Recetas</label><select id=\"zrecipes\" class=\"input\" multiple>${recOpts}</select></div>`) +
+                        row(inp('zjob','Job Lock','')) +
                         row(inp('zicon','Icono','fa-solid fa-hammer')) +
                         row(inp('zcpri','Color Primario','#53a88c') + inp('zcsec','Color Secundario','#2f7a62') + inp('zctitle','Título',''));
       } else if (t === 'cloakroom') {

--- a/qb-jobcreator/web/crafting.js
+++ b/qb-jobcreator/web/crafting.js
@@ -24,7 +24,6 @@ window.addEventListener('message', (e) => {
       if (th[k]) document.documentElement.style.setProperty(v, th[k]);
     });
     $('#craftTitleText').innerText = msg.title || th.titulo || CraftApp.locale.ui_title || 'KITCHEN';
-    $('#craftCategoryTag').innerText = msg.category || CraftApp.locale.ui_tab_food || 'FOOD';
     $('#craftPendingTitle').innerText = CraftApp.locale.queue_pending || 'PENDING ITEMS';
     $('#craftCollectTitle').innerText = CraftApp.locale.queue_collect || 'ITEMS TO COLLECT';
     $('#craftBtnLeaveAll').innerText = CraftApp.locale.leave_all || 'LEAVE ALL QUEUES';


### PR DESCRIPTION
## Summary
- stop collecting and saving `zone.data.category`
- rely only on `allowedCategories` or `recipes` for crafting zones
- document new behavior and adjust tests

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b392a4f2f483268ea1bdb95f624d8e