### PR TITLE
feat(jobcreator): support alternate theme colors

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -185,7 +185,9 @@ local function LoadAll()
       if type(data.theme) == 'table' then
         data.theme = {
           colorPrimario = type(data.theme.colorPrimario) == 'string' and data.theme.colorPrimario or nil,
+          colorPrimarioAlt = type(data.theme.colorPrimarioAlt) == 'string' and data.theme.colorPrimarioAlt or nil,
           colorSecundario = type(data.theme.colorSecundario) == 'string' and data.theme.colorSecundario or nil,
+          colorSecundarioAlt = type(data.theme.colorSecundarioAlt) == 'string' and data.theme.colorSecundarioAlt or nil,
           titulo = type(data.theme.titulo) == 'string' and data.theme.titulo or nil,
         }
       else
@@ -551,7 +553,9 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
       local th = zone.data.theme
       zone.data.theme = {
         colorPrimario = type(th.colorPrimario) == 'string' and th.colorPrimario or nil,
+        colorPrimarioAlt = type(th.colorPrimarioAlt) == 'string' and th.colorPrimarioAlt or nil,
         colorSecundario = type(th.colorSecundario) == 'string' and th.colorSecundario or nil,
+        colorSecundarioAlt = type(th.colorSecundarioAlt) == 'string' and th.colorSecundarioAlt or nil,
         titulo = type(th.titulo) == 'string' and th.titulo or nil,
       }
     else
@@ -581,7 +585,9 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     if type(nz.data.theme) == 'table' then
       nz.data.theme = {
         colorPrimario = type(nz.data.theme.colorPrimario) == 'string' and nz.data.theme.colorPrimario or nil,
+        colorPrimarioAlt = type(nz.data.theme.colorPrimarioAlt) == 'string' and nz.data.theme.colorPrimarioAlt or nil,
         colorSecundario = type(nz.data.theme.colorSecundario) == 'string' and nz.data.theme.colorSecundario or nil,
+        colorSecundarioAlt = type(nz.data.theme.colorSecundarioAlt) == 'string' and nz.data.theme.colorSecundarioAlt or nil,
         titulo = type(nz.data.theme.titulo) == 'string' and nz.data.theme.titulo or nil,
       }
     else
@@ -825,7 +831,9 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
       if type(data.theme) == 'table' then
         data.theme = {
           colorPrimario = type(data.theme.colorPrimario) == 'string' and data.theme.colorPrimario or nil,
+          colorPrimarioAlt = type(data.theme.colorPrimarioAlt) == 'string' and data.theme.colorPrimarioAlt or nil,
           colorSecundario = type(data.theme.colorSecundario) == 'string' and data.theme.colorSecundario or nil,
+          colorSecundarioAlt = type(data.theme.colorSecundarioAlt) == 'string' and data.theme.colorSecundarioAlt or nil,
           titulo = type(data.theme.titulo) == 'string' and data.theme.titulo or nil,
         }
       else
@@ -852,7 +860,9 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
           if type(nd.theme) == 'table' then
             nd.theme = {
               colorPrimario = type(nd.theme.colorPrimario) == 'string' and nd.theme.colorPrimario or nil,
+              colorPrimarioAlt = type(nd.theme.colorPrimarioAlt) == 'string' and nd.theme.colorPrimarioAlt or nil,
               colorSecundario = type(nd.theme.colorSecundario) == 'string' and nd.theme.colorSecundario or nil,
+              colorSecundarioAlt = type(nd.theme.colorSecundarioAlt) == 'string' and nd.theme.colorSecundarioAlt or nil,
               titulo = type(nd.theme.titulo) == 'string' and nd.theme.titulo or nil,
             }
           else

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -740,9 +740,11 @@ const App = (() => {
                             const icon = document.getElementById('zicon')?.value || '';
                             if (icon) data.icon = icon;
                             const colorPrimario = document.getElementById('zcpri')?.value || '';
+                            const colorPrimarioAlt = document.getElementById('zcpria')?.value || '';
                             const colorSecundario = document.getElementById('zcsec')?.value || '';
+                            const colorSecundarioAlt = document.getElementById('zcseca')?.value || '';
                             const titulo = document.getElementById('zctitle')?.value || '';
-                            data.theme = { colorPrimario, colorSecundario, titulo };
+                            data.theme = { colorPrimario, colorPrimarioAlt, colorSecundario, colorSecundarioAlt, titulo };
                            }
         if (t === 'cloakroom') data.mode = (document.getElementById('zckmode')?.value || 'illenium').toLowerCase();
         if (t === 'shop')  { data.items = collectShopItems(); }
@@ -808,7 +810,8 @@ const App = (() => {
                         row(`<div style="flex:1"><label>Recetas</label><select id="zrecipes" class="input" multiple>${recOpts}</select></div>`) +
                         row(inp('zjob','Job Lock','', jobVal)) +
                         row(inp('zicon','Icono','fa-solid fa-hammer', d.icon || '')) +
-                        row(inp('zcpri','Color Primario','#53a88c', th.colorPrimario || '') + inp('zcsec','Color Secundario','#2f7a62', th.colorSecundario || '') + inp('zctitle','Título','', th.titulo || ''));
+                        row(inp('zcpri','Color Primario','#53a88c', th.colorPrimario || '') + inp('zcpria','Color Primario Alt','#53a88c', th.colorPrimarioAlt || '')) +
+                        row(inp('zcsec','Color Secundario','#2f7a62', th.colorSecundario || '') + inp('zcseca','Color Secundario Alt','#2f7a62', th.colorSecundarioAlt || '') + inp('zctitle','Título','', th.titulo || ''));
         } else if (t === 'cloakroom') {
           box.innerHTML = row(inp('zckmode','Modo','illenium / qb-clothing', d.mode || ''));
         } else if (t === 'shop') {
@@ -877,10 +880,12 @@ const App = (() => {
             const icon = document.getElementById('zicon')?.value || '';
             if (icon) data.icon = icon;
             const colorPrimario = document.getElementById('zcpri')?.value || '';
+            const colorPrimarioAlt = document.getElementById('zcpria')?.value || '';
             const colorSecundario = document.getElementById('zcsec')?.value || '';
+            const colorSecundarioAlt = document.getElementById('zcseca')?.value || '';
             const titulo = document.getElementById('zctitle')?.value || '';
-            data.theme = { colorPrimario, colorSecundario, titulo };
-          }
+            data.theme = { colorPrimario, colorPrimarioAlt, colorSecundario, colorSecundarioAlt, titulo };
+            }
           if (t === 'cloakroom') data.mode = (document.getElementById('zckmode')?.value || 'illenium').toLowerCase();
           if (t === 'shop')  { data.items = collectShopItems(); }
           if (t === 'collect'){ data.item = document.getElementById('zitem')?.value||'material';
@@ -945,7 +950,8 @@ const App = (() => {
                         row(`<div style=\"flex:1\"><label>Recetas</label><select id=\"zrecipes\" class=\"input\" multiple>${recOpts}</select></div>`) +
                         row(inp('zjob','Job Lock','')) +
                         row(inp('zicon','Icono','fa-solid fa-hammer')) +
-                        row(inp('zcpri','Color Primario','#53a88c') + inp('zcsec','Color Secundario','#2f7a62') + inp('zctitle','Título',''));
+                        row(inp('zcpri','Color Primario','#53a88c') + inp('zcpria','Color Primario Alt','#53a88c')) +
+                        row(inp('zcsec','Color Secundario','#2f7a62') + inp('zcseca','Color Secundario Alt','#2f7a62') + inp('zctitle','Título',''));
       } else if (t === 'cloakroom') {
         box.innerHTML = row(inp('zckmode','Modo','illenium / qb-clothing'));
       } else if (t === 'shop') {


### PR DESCRIPTION
## Summary
- capture colorPrimarioAlt and colorSecundarioAlt in crafting zone forms
- preserve new color fields when sanitizing theme data server-side

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3982b987c83269993fbaddec2591e