### PR TITLE
feat(jobcreator): allow exporting jobs

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -163,6 +163,12 @@ RegisterNUICallback('deleteGrade', function(data, cb)
   cb({ ok = true })
 end)
 
+RegisterNUICallback('exportJobs', function(_, cb)
+  QBCore.Functions.TriggerCallback('qb-jobcreator:server:exportJobs', function(ok)
+    cb({ ok = ok })
+  end)
+end)
+
 -- ===== Empleados =====
 RegisterNUICallback('getEmployees', function(data, cb) QBCore.Functions.TriggerCallback('qb-jobcreator:server:getEmployees', function(list) cb(list or {}) end, data.job) end)
 RegisterNUICallback('fire', function(data, cb) TriggerServerEvent('qb-jobcreator:server:fire', data.job, data.citizenid); cb({ ok = true }) end)

--- a/qb-jobcreator/server/jobsfile.lua
+++ b/qb-jobcreator/server/jobsfile.lua
@@ -55,4 +55,14 @@ function JobsFile.Save(jobs)
   SaveResourceFile(RESOURCE, FILE, table.concat(lines, '\n') .. '\n', -1)
 end
 
+-- Export current QBCore shared jobs table to the shared/jobs.lua file
+function JobsFile.Export()
+  local ok, err = pcall(JobsFile.Save)
+  if not ok then
+    print('JobsFile.Export error:', err)
+    return false
+  end
+  return true
+end
+
 return JobsFile

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -311,6 +311,12 @@ QBCore.Commands.Add('jobcreator', _L('open_creator'), {}, false, function(src)
   TriggerClientEvent('qb-jobcreator:client:openUI', src)
 end)
 
+-- ===== Exportar trabajos =====
+QBCore.Functions.CreateCallback('qb-jobcreator:server:exportJobs', function(src, cb)
+  if not ensurePerm(src) then return cb(false) end
+  cb(JobsFile.Export())
+end)
+
 -- ===== Dashboard =====
 QBCore.Functions.CreateCallback('qb-jobcreator:server:getDashboard', function(src, cb)
   local ok, result = pcall(function()

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -354,27 +354,12 @@ const App = (() => {
   }
 
   $('#btn-addjob').addEventListener('click', () => openJobModal());
-  $('#btn-export').addEventListener('click', () => {
-    try {
-      const arr = Object.values(state.jobs);
-      const text = JSON.stringify(arr);
-      if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(text)
-          .then(() => toast('Exportado al portapapeles', 'success'))
-          .catch(() => { fallbackCopy(text); toast('Copiado con método alterno', 'success'); });
-      } else { fallbackCopy(text); toast('Copiado con método alterno', 'success'); }
-    } catch { toast('No se pudo exportar', 'error'); }
+  $('#btn-export').addEventListener('click', async () => {
+    const res = await postJ('exportJobs');
+    if (res && res.ok) toast('Exportado correctamente', 'success');
+    else toast('No se pudo exportar', 'error');
   });
   $('#btn-import').addEventListener('click', () => openImportModal());
-
-  function fallbackCopy(text) {
-    const ta = document.createElement('textarea');
-    ta.value = text;
-    document.body.appendChild(ta);
-    ta.select();
-    document.execCommand('copy');
-    document.body.removeChild(ta);
-  }
 
   function renderJobs() {
     const tb = $('#jobsTable tbody');


### PR DESCRIPTION
## Summary
- add JobsFile.Export to persist current QBCore jobs
- expose admin-only RPC `qb-jobcreator:server:exportJobs`
- trigger export from web UI button

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3aa8f218c8326a2a5053ef3093c1c