### PR TITLE
feat: custom blip sprites for job zones

### DIFF
--- a/qb-jobcreator/README.md
+++ b/qb-jobcreator/README.md
@@ -60,3 +60,13 @@ UseQbInventory = false, -- fuerza el uso de qb-inventory
 ```
 
 Las funciones de manejo de inventario (`HasItem`, `RemoveItem` y `AddItem`) detectan automáticamente `ox_inventory` y utilizan la integración apropiada.
+
+## Texturas personalizadas para blips
+
+Puedes utilizar iconos propios en los blips del mapa.
+
+1. Coloca los archivos `.ytd` con tus texturas dentro de una carpeta `stream/` en este recurso.  Asegúrate de declarar `files {'stream/*.ytd'}` en `fxmanifest.lua` si aún no existe.
+2. Desde la interfaz web, al crear o editar una zona, rellena los campos **Sprite**, **Color**, **YTD Dict** (nombre del archivo sin la extensión) y **YTD Name** (nombre de la textura dentro del diccionario).
+3. El cliente cargará ese diccionario mediante `RequestStreamedTextureDict` y aplicará el sprite seleccionado con `SetBlipSprite`.
+
+De esta manera puedes mostrar iconos personalizados en el mapa para cada zona.

--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -549,8 +549,15 @@ RegisterNetEvent('qb-jobcreator:client:rebuildZones', function(zones)
   for _, z in ipairs(zones or {}) do
     Active[#Active+1] = z
     if z.ztype == 'blip' then
+      if z.ytdDict then
+        RequestStreamedTextureDict(z.ytdDict, false)
+        while not HasStreamedTextureDictLoaded(z.ytdDict) do Wait(0) end
+      end
       local blip = AddBlipForCoord(z.coords.x, z.coords.y, z.coords.z)
-      SetBlipSprite(blip, Config.Zone.BlipSprite); SetBlipColour(blip, Config.Zone.BlipColor)
+      local sprite = z.sprite or Config.Zone.BlipSprite
+      if z.ytdName then sprite = GetHashKey(z.ytdName) end
+      SetBlipSprite(blip, sprite)
+      SetBlipColour(blip, z.color or Config.Zone.BlipColor)
       SetBlipScale(blip, 0.8); SetBlipAsShortRange(blip, true)
       BeginTextCommandSetBlipName('STRING'); AddTextComponentString(z.label or ('Punto '..z.job)); EndTextCommandSetBlipName(blip)
     else

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -735,6 +735,12 @@ const App = (() => {
           <div><label>Limpieza (m)</label><input id="zclearrad" class="input" value="${(zone.data && zone.data.clearRadius) || 0}"/></div>
           <div><button id="zcoords" class="btn">Usar mis coords</button></div>
         </div>
+        <div class="row">
+          <div><label>Sprite</label><input id="zsprite" class="input" value="${zone.sprite ?? ''}"/></div>
+          <div><label>Color</label><input id="zcolor" class="input" value="${zone.color ?? ''}"/></div>
+          <div><label>YTD Dict</label><input id="zytddict" class="input" value="${zone.ytdDict || ''}"/></div>
+          <div><label>YTD Name</label><input id="zytdname" class="input" value="${zone.ytdName || ''}"/></div>
+        </div>
         <div id="zextra"></div>`;
       modal('Editar ' + zone.ztype, base, () => {
         const t = zone.ztype;
@@ -785,7 +791,11 @@ const App = (() => {
         const cr = Number(document.getElementById('zclearrad')?.value || 0);
         data.clearArea = cr > 0;
         data.clearRadius = cr;
-        post('updateZone', { id, data, label: document.getElementById('zlabel').value, radius: Number(document.getElementById('zrad').value) || 2.0, coords }).then(() => { closeModal(); load(); });
+        const sprite = Number(document.getElementById('zsprite')?.value);
+        const color = Number(document.getElementById('zcolor')?.value);
+        const ytdDict = document.getElementById('zytddict')?.value || '';
+        const ytdName = document.getElementById('zytdname')?.value || '';
+        post('updateZone', { id, data, label: document.getElementById('zlabel').value, radius: Number(document.getElementById('zrad').value) || 2.0, coords, sprite, color, ytdDict, ytdName }).then(() => { closeModal(); load(); });
       });
 
       document.getElementById('zcoords').onclick = () => {
@@ -871,6 +881,12 @@ const App = (() => {
         <div class="row">
           <div><label>Radio</label><input id="zrad" class="input" value="2.0"/></div>
           <div><label>Limpieza (m)</label><input id="zclearrad" class="input" value="0"/></div>
+          <div><label>Sprite</label><input id="zsprite" class="input"/></div>
+          <div><label>Color</label><input id="zcolor" class="input"/></div>
+        </div>
+        <div class="row">
+          <div><label>YTD Dict</label><input id="zytddict" class="input"/></div>
+          <div><label>YTD Name</label><input id="zytdname" class="input"/></div>
           <div><label>Usar mis coords</label><div class="h">Se capturarán al guardar</div></div>
         </div>
         <div id="zextra"></div>`;
@@ -931,6 +947,10 @@ const App = (() => {
             label: document.getElementById('zlabel').value,
             radius: Number(document.getElementById('zrad').value) || 2.0,
             coords: c,
+            sprite: Number(document.getElementById('zsprite')?.value),
+            color: Number(document.getElementById('zcolor')?.value),
+            ytdDict: document.getElementById('zytddict')?.value || '',
+            ytdName: document.getElementById('zytdname')?.value || '',
             data,
           };
           post('createZone', z).then(() => { closeModal(); load(); });


### PR DESCRIPTION
## Summary
- allow zones to define sprite, color and optional texture dictionary
- load custom textures client-side and apply blip settings
- add UI fields and README docs for streaming custom `.ytd` icons

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `luac -p qb-jobcreator/server/main.lua`
- `luac -p qb-jobcreator/client/zones.lua` *(fails: unexpected symbol near ``prop_mp_arrow_barrier``)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b3c15ba08326b105602702297884