### PR TITLE
feat: add debug logging for job zones

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -62,6 +62,8 @@ end
 local function canUseZone(z, requireBoss)
   local name, grade, isboss = playerJobData()
   local inJob = (name == z.job) or hasMultiJob(z.job)
+  print(('[qb-jobcreator] canUseZone ztype=%s job=%s playerJob=%s grade=%s isboss=%s requireBoss=%s inJob=%s'):format(
+    tostring(z and z.ztype), tostring(z and z.job), tostring(name), tostring(grade), tostring(isboss), tostring(requireBoss), tostring(inJob)))
   if not inJob then return false end
   if requireBoss and not isboss then return false end
   local minG = 0
@@ -209,6 +211,8 @@ local function addTargetForZone(z)
   local distance = radius + 1.0
   local opts = {}
   local usingTarget = GetResourceState('qb-target') == 'started'
+  -- Debug: log zone type and qb-target state
+  print(('[qb-jobcreator] addTargetForZone ztype=%s usingTarget=%s'):format(tostring(z.ztype), tostring(usingTarget)))
   if not usingTarget then
     print(('[qb-jobcreator] qb-target no iniciado, usando fallback para %s'):format(name))
   end
@@ -457,6 +461,17 @@ local function addTargetForZone(z)
       label = 'Craftear', icon = 'fa-solid fa-hammer',
       canInteract = function() return canUseZone(z, false) end,
       action = function() openCraftMenu(z) end
+    })
+  end
+
+  -- Debug: show built options for this zone
+  print(('[qb-jobcreator] options for %s (%s): %s'):format(name, tostring(z.ztype), json.encode(opts)))
+  if #opts == 0 then
+    print(('[qb-jobcreator] zona %s (%s) sin acciones, añadiendo placeholder'):format(name, tostring(z.ztype)))
+    table.insert(opts, {
+      label = 'Sin acciones configuradas', icon = 'fa-solid fa-ban',
+      canInteract = function() return true end,
+      action = function() QBCore.Functions.Notify('Zona sin acciones configuradas', 'error') end
     })
   end
 

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -265,6 +265,8 @@ local function LoadAll()
     }
     ExtractBlipInfo(data, zone)
     Runtime.Zones[#Runtime.Zones+1] = zone
+    print(('[qb-jobcreator] Loaded zone id=%s type=%s job=%s radius=%s'):format(
+      tostring(zone.id), tostring(zone.ztype), tostring(zone.job), tostring(zone.radius)))
     if z.ztype == 'music' then
       local name = (data and (data.name or data.djName)) or ('jc_ms_'..z.job..'_'..z.id)
       local range = tonumber(data and (data.range or data.distance)) or 20.0
@@ -277,6 +279,7 @@ local function LoadAll()
     end
   end
   TriggerClientEvent('qb-jobcreator:client:syncAll', -1, Runtime.Jobs, Runtime.Zones)
+  print(('[qb-jobcreator] Enviando %d zonas al cliente'):format(#Runtime.Zones))
   TriggerClientEvent('qb-jobcreator:client:rebuildZones', -1, Runtime.Zones)
 end
 


### PR DESCRIPTION
## Summary
- log zone type, qb-target status, and built options when creating target zones
- include placeholder interaction for zones without actions
- print server-side zone data (type/job/radius) when syncing

## Testing
- `for f in tests/*.lua; do echo "Running $f"; lua $f; done` *(fails: command not found: lua)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bed0eb8c8326adf6bc79163f580c