### PR TITLE
feat: add zone interaction modes

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -115,6 +115,11 @@ local function ValidateZoneData(zone)
   end
   local r = tonumber(zone.radius)
   if not r or r <= 0 then return false, 'Radio debe ser mayor a 0' end
+  local i = zone.data and zone.data.interaction
+  if i ~= nil then
+    if type(i) ~= 'string' then return false, 'Interacción inválida' end
+    if i ~= 'target' and i ~= 'textui' and i ~= '3dtext' then return false, 'Interacción inválida' end
+  end
   return true
 end
 
@@ -618,6 +623,12 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     if zone.data.clearRadius ~= nil then
       zone.data.clearRadius = tonumber(zone.data.clearRadius) or Config.Zone.ClearRadius
     end
+    local inter = zone.data.interaction
+    if inter == 'target' or inter == 'textui' or inter == '3dtext' then
+      zone.data.interaction = inter
+    else
+      zone.data.interaction = 'target'
+    end
   end
   if zone.ztype == 'shop' then
     zone.data.items = SanitizeShopItems(zone.data.items)
@@ -659,6 +670,10 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     coords = json.decode(r.coords or '{}') or {}, radius = r.radius or 2.0,
     data = json.decode(r.data or '{}') or {}
   }
+  local nzInter = nz.data.interaction
+  if nzInter ~= 'target' and nzInter ~= 'textui' and nzInter ~= '3dtext' then
+    nz.data.interaction = 'target'
+  end
   ExtractBlipInfo(nz.data, nz)
   if nz.ztype == 'shop' then
     nz.data.items = SanitizeShopItems(nz.data.items)
@@ -952,6 +967,12 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
         data.theme = nil
       end
     end
+    local inter = data.interaction
+    if inter == 'target' or inter == 'textui' or inter == '3dtext' then
+      data.interaction = inter
+    else
+      data.interaction = 'target'
+    end
     data.clearArea = data.clearArea and true or false
     if data.clearRadius ~= nil then data.clearRadius = tonumber(data.clearRadius) or Config.Zone.ClearRadius end
   end
@@ -963,6 +984,10 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
     for idx, z in ipairs(Runtime.Zones) do
       if z.id == id then
         local nd = json.decode(r.data or '{}') or {}
+        local inter = nd.interaction
+        if inter ~= 'target' and inter ~= 'textui' and inter ~= '3dtext' then
+          nd.interaction = 'target'
+        end
         if ztype == 'shop' then
           nd.items = SanitizeShopItems(nd.items)
         elseif ztype == 'crafting' then

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -752,12 +752,20 @@ const App = (() => {
       const zone = zonesCache.find((z) => z.id === id);
       if (!zone) return;
       let coords = zone.coords;
+      const inter = (zone.data && zone.data.interaction) || (window.Config?.InteractionMode || 'target');
       const base = `
         <div class="row">
           <div><label>Etiqueta</label><input id="zlabel" class="input" value="${zone.label || ''}"/></div>
           <div><label>Radio</label><input id="zrad" class="input" value="${zone.radius || 2.0}"/></div>
           <div><label>Limpieza (m)</label><input id="zclearrad" class="input" value="${(zone.data && zone.data.clearRadius) || 0}"/></div>
           <div><button id="zcoords" class="btn">Usar mis coords</button></div>
+        </div>
+        <div class="row">
+          <div><label>Interacción</label><select id="zinteraction" class="input">
+            <option value="target" ${inter === 'target' ? 'selected' : ''}>qb-target</option>
+            <option value="textui" ${inter === 'textui' ? 'selected' : ''}>TextUI</option>
+            <option value="3dtext" ${inter === '3dtext' ? 'selected' : ''}>3D Text</option>
+          </select></div>
         </div>
         <div class="row">
           <div><label>Sprite</label><input id="zsprite" class="input" value="${zone.sprite ?? ''}"/></div>
@@ -768,7 +776,7 @@ const App = (() => {
         <div id="zextra"></div>`;
       modal('Editar ' + zone.ztype, base, () => {
         const t = zone.ztype;
-        const data = {};
+        const data = { interaction: document.getElementById('zinteraction')?.value || 'target' };
         if (t === 'boss')   data.minGrade = Number(document.getElementById('zmin')?.value || 0);
         if (t === 'stash') { data.slots  = Number(document.getElementById('zslots')?.value || 50);
                             data.weight = Number(document.getElementById('zweight')?.value || 400000); }
@@ -891,6 +899,7 @@ const App = (() => {
     }
 
     document.getElementById('addz').onclick = () => {
+      const interDef = window.Config?.InteractionMode || 'target';
       const base = `
         <div class="row">
           <div>
@@ -901,6 +910,13 @@ const App = (() => {
             </select>
           </div>
           <div><label>Etiqueta</label><input id="zlabel" class="input" required/></div>
+        </div>
+        <div class="row">
+          <div><label>Interacción</label><select id="zinteraction" class="input">
+            <option value="target" ${interDef === 'target' ? 'selected' : ''}>qb-target</option>
+            <option value="textui" ${interDef === 'textui' ? 'selected' : ''}>TextUI</option>
+            <option value="3dtext" ${interDef === '3dtext' ? 'selected' : ''}>3D Text</option>
+          </select></div>
         </div>
         <div class="row">
           <div><label>Radio</label><input id="zrad" class="input" type="number" value="2.0" min="0.1"/></div>
@@ -924,7 +940,7 @@ const App = (() => {
           if (!label) { toast('Etiqueta requerida', 'error'); return; }
           if (!radius || radius <= 0) { toast('Radio inválido', 'error'); return; }
           if (!validTypes.includes(t)) { toast('Tipo de zona inválido', 'error'); return; }
-          const data = {};
+          const data = { interaction: document.getElementById('zinteraction')?.value || 'target' };
           if (t === 'boss')   data.minGrade = Number(document.getElementById('zmin')?.value || 0);
           if (t === 'stash') { data.slots  = Number(document.getElementById('zslots')?.value || 50);
                               data.weight = Number(document.getElementById('zweight')?.value || 400000); }


### PR DESCRIPTION
## Summary
- add per-zone interaction mode selector in web UI
- support target, textui and 3dtext modes client-side
- validate and store interaction mode on the server

## Testing
- `lua qb-jobcreator/tests/validation_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3c06b29cc8326ade9e40c15f520b1