### PR TITLE
feat: custom zone action labels

### DIFF
--- a/qb-jobcreator/README.md
+++ b/qb-jobcreator/README.md
@@ -70,3 +70,11 @@ Puedes utilizar iconos propios en los blips del mapa.
 3. El cliente cargará ese diccionario mediante `RequestStreamedTextureDict` y aplicará el sprite seleccionado con `SetBlipSprite`.
 
 De esta manera puedes mostrar iconos personalizados en el mapa para cada zona.
+
+## Icono y etiqueta de acción personalizados
+
+Al crear o editar una zona desde la interfaz web ahora puedes definir los campos
+**Icono acción** y **Etiqueta acción**. Estos valores se almacenan en
+`zone.data.icon` y `zone.data.label` y se utilizan para construir la opción de
+interacción que ve el jugador (qb-target, TextUI o 3D Text). El icono acepta
+clases de [Font Awesome](https://fontawesome.com/) como `fa-solid fa-car`.

--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -212,6 +212,9 @@ local function addTargetForZone(z)
   local size = (radius + 0.5) * 2.0
   local distance = radius + 1.0
   local opts = {}
+  local d = z.data or {}
+  local dLabel = d.label
+  local dIcon = d.icon
   print(('[qb-jobcreator] addTargetForZone ztype=%s mode=%s usingTarget=%s'):format(tostring(z.ztype), tostring(interaction), tostring(usingTarget)))
   if interaction == 'target' and not usingTarget then
     print(('[qb-jobcreator] qb-target no iniciado, usando fallback para %s'):format(name))
@@ -219,14 +222,14 @@ local function addTargetForZone(z)
 
   if z.ztype == 'boss' then
     table.insert(opts, {
-      label = 'Abrir gestión del trabajo', icon = 'fa-solid fa-briefcase',
+      label = dLabel or 'Abrir gestión del trabajo', icon = dIcon or 'fa-solid fa-briefcase',
       canInteract = function() return canUseZone(z, true) end,
       action = function() TriggerServerEvent('qb-jobcreator:server:openBossPanel', z.job) end
     })
 
   elseif z.ztype == 'stash' then
     table.insert(opts, {
-      label = 'Abrir Almacén', icon = 'fa-solid fa-box',
+      label = dLabel or 'Abrir Almacén', icon = dIcon or 'fa-solid fa-box',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         TriggerServerEvent('qb-jobcreator:server:openStash', z.id)
@@ -235,7 +238,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'garage' then
     table.insert(opts, {
-      label = 'Sacar vehículo de trabajo', icon = 'fa-solid fa-car',
+      label = dLabel or 'Sacar vehículo de trabajo', icon = dIcon or 'fa-solid fa-car',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local _, myGrade = playerJobData()
@@ -251,7 +254,7 @@ local function addTargetForZone(z)
     })
 
     table.insert(opts, {
-      label = 'Guardar vehículo', icon = 'fa-solid fa-warehouse',
+      label = dLabel or 'Guardar vehículo', icon = dIcon or 'fa-solid fa-warehouse',
       canInteract = function()
         local ped = PlayerPedId()
         local veh = GetVehiclePedIsIn(ped, false)
@@ -262,7 +265,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'cloakroom' then
     table.insert(opts, {
-      label = 'Vestuario', icon = 'fa-solid fa-shirt',
+      label = dLabel or 'Vestuario', icon = dIcon or 'fa-solid fa-shirt',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local data = z.data or {}
@@ -284,7 +287,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'shop' then
     table.insert(opts, {
-      label = 'Abrir tienda', icon = 'fa-solid fa-store',
+      label = dLabel or 'Abrir tienda', icon = dIcon or 'fa-solid fa-store',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         TriggerServerEvent('qb-jobcreator:server:getShopItems', z.id)
@@ -293,7 +296,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'collect' then
     table.insert(opts, {
-      label = 'Recolectar', icon = 'fa-solid fa-box-open',
+      label = dLabel or 'Recolectar', icon = dIcon or 'fa-solid fa-box-open',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local data = z.data or {}
@@ -307,7 +310,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'spawner' then
     table.insert(opts, {
-      label = 'Usar', icon = 'fa-solid fa-cubes',
+      label = dLabel or 'Usar', icon = dIcon or 'fa-solid fa-cubes',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local model = (z.data and z.data.prop) or 'prop_toolchest_05'
@@ -322,7 +325,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'sell' then
     table.insert(opts, {
-      label = 'Vender material', icon = 'fa-solid fa-sack-dollar',
+      label = dLabel or 'Vender material', icon = dIcon or 'fa-solid fa-sack-dollar',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         TriggerServerEvent('qb-jobcreator:server:sell', z.id)
@@ -331,7 +334,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'register' then
     table.insert(opts, {
-      label = 'Cobrar a cercano', icon = 'fa-solid fa-cash-register',
+      label = dLabel or 'Cobrar a cercano', icon = dIcon or 'fa-solid fa-cash-register',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local sid = GetClosestPlayerToMe(3.0)
@@ -342,7 +345,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'alarm' then
     table.insert(opts, {
-      label = 'Activar alarma', icon = 'fa-solid fa-bell',
+      label = dLabel or 'Activar alarma', icon = dIcon or 'fa-solid fa-bell',
       canInteract = function() return canUseZone(z, true) end,
       action = function()
         TriggerServerEvent('qb-jobcreator:server:alarm', z.job, (z.data and z.data.code) or 'panic')
@@ -351,7 +354,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'anim' then
     table.insert(opts, {
-      label = z.label or 'Usar animación', icon = 'fa-solid fa-person',
+      label = dLabel or z.label or 'Usar animación', icon = dIcon or 'fa-solid fa-person',
       canInteract = function() return canUseZone(z, false) end,
       action = function()
         local d = z.data or {}
@@ -367,7 +370,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'music' then
     table.insert(opts, {
-      label = 'Reproducir música', icon = 'fa-solid fa-music',
+      label = dLabel or 'Reproducir música', icon = dIcon or 'fa-solid fa-music',
       canInteract = function() return canUseZone(z, false) and GetResourceState('myDj')=='started' end,
       action = function()
         local d = z.data or {}
@@ -391,7 +394,7 @@ local function addTargetForZone(z)
         local options = {}
         if from ~= 0 then
           table.insert(options, {
-            label = z.label or 'Origen', icon = 'fa-solid fa-person-arrow-up-from-line',
+            label = dLabel or z.label or 'Origen', icon = dIcon or 'fa-solid fa-person-arrow-up-from-line',
             canInteract = function() return canUseZone(z, false) end,
             action = function() TriggerServerEvent('qb-jobcreator:server:teleport', z.id, from, 0) end
           })
@@ -399,7 +402,7 @@ local function addTargetForZone(z)
         for i, dest in ipairs(dests) do
           if i ~= from then
             table.insert(options, {
-              label = dest.label or ('Destino '..i), icon = 'fa-solid fa-person-arrow-up-from-line',
+              label = dLabel or dest.label or ('Destino '..i), icon = dIcon or 'fa-solid fa-person-arrow-up-from-line',
               canInteract = function() return canUseZone(z, false) end,
               action = function() TriggerServerEvent('qb-jobcreator:server:teleport', z.id, from, i) end
             })
@@ -411,7 +414,7 @@ local function addTargetForZone(z)
       if #dests == 0 then
         opts = {
           {
-            label = 'Teletransportar', icon = 'fa-solid fa-person-arrow-up-from-line',
+            label = dLabel or 'Teletransportar', icon = dIcon or 'fa-solid fa-person-arrow-up-from-line',
             canInteract = function() return false end,
             action = function() QBCore.Functions.Notify('Destino no configurado.', 'error') end
           }
@@ -432,7 +435,7 @@ local function addTargetForZone(z)
     else
       opts = {
         {
-          label = 'Teletransportar', icon = 'fa-solid fa-person-arrow-up-from-line',
+          label = dLabel or 'Teletransportar', icon = dIcon or 'fa-solid fa-person-arrow-up-from-line',
           canInteract = function() return canUseZone(z, false) end,
           action = function()
             if #dests == 0 then
@@ -443,7 +446,7 @@ local function addTargetForZone(z)
               local menu = { { header = 'Selecciona destino', isMenuHeader = true } }
               for i, dest in ipairs(dests) do
                 menu[#menu+1] = {
-                  header = dest.label or ('Destino '..i),
+                  header = dLabel or dest.label or ('Destino '..i),
                   params = { event = 'qb-jobcreator:client:teleportSelect', args = { zone = z.id, index = i } }
                 }
               end
@@ -458,7 +461,7 @@ local function addTargetForZone(z)
 
   elseif z.ztype == 'crafting' then
     table.insert(opts, {
-      label = 'Craftear', icon = 'fa-solid fa-hammer',
+      label = dLabel or 'Craftear', icon = dIcon or 'fa-solid fa-hammer',
       canInteract = function() return canUseZone(z, false) end,
       action = function() openCraftMenu(z) end
     })

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -249,7 +249,6 @@ local function LoadAll()
       data.allowedCategories = SanitizeCategoryList(data.allowedCategories)
       data.recipes = SanitizeRecipeList(data.recipes)
       if type(data.job) ~= 'string' and type(data.job) ~= 'table' then data.job = nil end
-      data.icon = type(data.icon) == 'string' and data.icon or nil
       if type(data.theme) == 'table' then
         data.theme = {
           colorPrimario = type(data.theme.colorPrimario) == 'string' and data.theme.colorPrimario or nil,
@@ -262,6 +261,8 @@ local function LoadAll()
         data.theme = nil
       end
     end
+    data.icon = type(data.icon) == 'string' and data.icon or nil
+    data.label = type(data.label) == 'string' and data.label or nil
     local coords = json.decode(z.coords or '{}') or {}
     local zone = {
       id = z.id, job = z.job, ztype = z.ztype, label = z.label,
@@ -629,6 +630,8 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     else
       zone.data.interaction = 'target'
     end
+    zone.data.icon = type(zone.data.icon) == 'string' and zone.data.icon or nil
+    zone.data.label = type(zone.data.label) == 'string' and zone.data.label or nil
   end
   if zone.ztype == 'shop' then
     zone.data.items = SanitizeShopItems(zone.data.items)
@@ -644,7 +647,6 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     else
       zone.data.job = nil
     end
-    zone.data.icon = type(zone.data.icon) == 'string' and zone.data.icon or nil
     if type(zone.data.theme) == 'table' then
       local th = zone.data.theme
       zone.data.theme = {
@@ -674,6 +676,8 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
   if nzInter ~= 'target' and nzInter ~= 'textui' and nzInter ~= '3dtext' then
     nz.data.interaction = 'target'
   end
+  nz.data.icon = type(nz.data.icon) == 'string' and nz.data.icon or nil
+  nz.data.label = type(nz.data.label) == 'string' and nz.data.label or nil
   ExtractBlipInfo(nz.data, nz)
   if nz.ztype == 'shop' then
     nz.data.items = SanitizeShopItems(nz.data.items)
@@ -683,7 +687,6 @@ RegisterNetEvent('qb-jobcreator:server:createZone', function(zone)
     if type(nz.data.job) ~= 'string' and type(nz.data.job) ~= 'table' then
       nz.data.job = nil
     end
-    nz.data.icon = type(nz.data.icon) == 'string' and nz.data.icon or nil
     if type(nz.data.theme) == 'table' then
       nz.data.theme = {
         colorPrimario = type(nz.data.theme.colorPrimario) == 'string' and nz.data.theme.colorPrimario or nil,
@@ -975,6 +978,8 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
     end
     data.clearArea = data.clearArea and true or false
     if data.clearRadius ~= nil then data.clearRadius = tonumber(data.clearRadius) or Config.Zone.ClearRadius end
+    data.icon = type(data.icon) == 'string' and data.icon or nil
+    data.label = type(data.label) == 'string' and data.label or nil
   end
   data = ApplyBlipInfo(data, { sprite = sprite, color = color, ytdDict = ytdDict, ytdName = ytdName })
   if DB.UpdateZone then DB.UpdateZone(id, { data = data, label = label, radius = radius, coords = coords }) end
@@ -988,13 +993,14 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
         if inter ~= 'target' and inter ~= 'textui' and inter ~= '3dtext' then
           nd.interaction = 'target'
         end
+        nd.icon = type(nd.icon) == 'string' and nd.icon or nil
+        nd.label = type(nd.label) == 'string' and nd.label or nil
         if ztype == 'shop' then
           nd.items = SanitizeShopItems(nd.items)
         elseif ztype == 'crafting' then
           nd.allowedCategories = SanitizeCategoryList(nd.allowedCategories)
           nd.recipes = SanitizeRecipeList(nd.recipes)
           if type(nd.job) ~= 'string' and type(nd.job) ~= 'table' then nd.job = nil end
-          nd.icon = type(nd.icon) == 'string' and nd.icon or nil
           if type(nd.theme) == 'table' then
             nd.theme = {
               colorPrimario = type(nd.theme.colorPrimario) == 'string' and nd.theme.colorPrimario or nil,

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -768,6 +768,10 @@ const App = (() => {
           </select></div>
         </div>
         <div class="row">
+          <div><label>Icono acción</label><input id="zacticon" class="input" value="${(zone.data && zone.data.icon) || ''}"/></div>
+          <div><label>Etiqueta acción</label><input id="zactlabel" class="input" value="${(zone.data && zone.data.label) || ''}"/></div>
+        </div>
+        <div class="row">
           <div><label>Sprite</label><input id="zsprite" class="input" value="${zone.sprite ?? ''}"/></div>
           <div><label>Color</label><input id="zcolor" class="input" value="${zone.color ?? ''}"/></div>
           <div><label>YTD Dict</label><input id="zytddict" class="input" value="${zone.ytdDict || ''}"/></div>
@@ -777,6 +781,10 @@ const App = (() => {
       modal('Editar ' + zone.ztype, base, () => {
         const t = zone.ztype;
         const data = { interaction: document.getElementById('zinteraction')?.value || 'target' };
+        const actIcon = document.getElementById('zacticon')?.value || '';
+        const actLabel = document.getElementById('zactlabel')?.value || '';
+        if (actIcon) data.icon = actIcon;
+        if (actLabel) data.label = actLabel;
         if (t === 'boss')   data.minGrade = Number(document.getElementById('zmin')?.value || 0);
         if (t === 'stash') { data.slots  = Number(document.getElementById('zslots')?.value || 50);
                             data.weight = Number(document.getElementById('zweight')?.value || 400000); }
@@ -919,6 +927,10 @@ const App = (() => {
           </select></div>
         </div>
         <div class="row">
+          <div><label>Icono acción</label><input id="zacticon" class="input"/></div>
+          <div><label>Etiqueta acción</label><input id="zactlabel" class="input"/></div>
+        </div>
+        <div class="row">
           <div><label>Radio</label><input id="zrad" class="input" type="number" value="2.0" min="0.1"/></div>
           <div><label>Limpieza (m)</label><input id="zclearrad" class="input" type="number" value="0" min="0"/></div>
           <div><label>Sprite</label><input id="zsprite" class="input" type="number"/></div>
@@ -941,6 +953,10 @@ const App = (() => {
           if (!radius || radius <= 0) { toast('Radio inválido', 'error'); return; }
           if (!validTypes.includes(t)) { toast('Tipo de zona inválido', 'error'); return; }
           const data = { interaction: document.getElementById('zinteraction')?.value || 'target' };
+          const actIcon = document.getElementById('zacticon')?.value || '';
+          const actLabel = document.getElementById('zactlabel')?.value || '';
+          if (actIcon) data.icon = actIcon;
+          if (actLabel) data.label = actLabel;
           if (t === 'boss')   data.minGrade = Number(document.getElementById('zmin')?.value || 0);
           if (t === 'stash') { data.slots  = Number(document.getElementById('zslots')?.value || 50);
                               data.weight = Number(document.getElementById('zweight')?.value || 400000); }


### PR DESCRIPTION
## Summary
- allow defining action icon and label when creating or editing zones
- propagate icon/label through zone data to clients
- render zone options with custom icon/label

## Testing
- `lua qb-jobcreator/tests/validation_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b3c6e25e74832684736c5ba2f133c4