### PR TITLE
refactor: centralize target interaction

### DIFF
--- a/qb-jobcreator/shared/sh_utils.lua
+++ b/qb-jobcreator/shared/sh_utils.lua
@@ -19,7 +19,14 @@ end
 Utils.HasOpenPermission = HasOpenPermission
 
 function UseTarget()
-  return Config.InteractionMode == 'target' and (Config.Integrations.UseQbTarget or Config.Integrations.UseOxTarget)
+  if Config.InteractionMode ~= 'target' then return false end
+  if Config.Integrations.UseQbTarget and GetResourceState('qb-target') == 'started' then
+    return 'qb-target'
+  end
+  if Config.Integrations.UseOxTarget and GetResourceState('ox_target') == 'started' then
+    return 'ox_target'
+  end
+  return false
 end
 Utils.UseTarget = UseTarget
 


### PR DESCRIPTION
## Summary
- use shared UseTarget() utility for interaction mode checks
- support both qb-target and ox_target from a single decision point

## Testing
- `lua qb-jobcreator/tests/validation_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b3cc25ad4083268a941a3e059488b7