### PR TITLE
feat(jobcreator): allow per-zone target override

### DIFF
--- a/qb-jobcreator/shared/sh_utils.lua
+++ b/qb-jobcreator/shared/sh_utils.lua
@@ -19,7 +19,6 @@ end
 Utils.HasOpenPermission = HasOpenPermission
 
 function UseTarget()
-  if Config.InteractionMode ~= 'target' then return false end
   if Config.Integrations.UseQbTarget and GetResourceState('qb-target') == 'started' then
     return 'qb-target'
   end


### PR DESCRIPTION
## Summary
- remove global interaction mode check from `UseTarget`
- ensure zone interactions still determine target usage

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/validation_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b496cb353c8326bf51e4995cc6ed30