### PR TITLE
Refactor job creator zones to use qb-target only

### DIFF
--- a/qb-jobcreator/config.lua
+++ b/qb-jobcreator/config.lua
@@ -78,6 +78,10 @@ Config.Integrations = Config.Integrations or {
   HospitalResources   = { 'ars_ambulancejob' },
 }
 
+-- Forzamos el uso exclusivo de qb-target
+Config.Integrations.UseQbTarget = true
+Config.Integrations.UseOxTarget = false
+
 -- ===== Multi‑trabajo =====
 -- Si usas un recurso de multitrabajo, activa esta sección para integrarlo.
 Config.MultiJob = Config.MultiJob or {

--- a/qb-jobcreator/shared/sh_utils.lua
+++ b/qb-jobcreator/shared/sh_utils.lua
@@ -22,9 +22,6 @@ function UseTarget()
   if Config.Integrations.UseQbTarget and GetResourceState('qb-target') == 'started' then
     return 'qb-target'
   end
-  if Config.Integrations.UseOxTarget and GetResourceState('ox_target') == 'started' then
-    return 'ox_target'
-  end
   return false
 end
 Utils.UseTarget = UseTarget


### PR DESCRIPTION
## Summary
- drop ox_target integration and remove icon fields
- register all zones and global interactions directly through qb-target
- force qb-target configuration

## Testing
- `lua qb-jobcreator/tests/validation_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4ace0c44c8326ad243a0ae9602623