### PR TITLE
Add heading to teleport coordinate callback

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -212,7 +212,12 @@ RegisterNUICallback('wash', function(data, cb) TriggerServerEvent('qb-jobcreator
 RegisterNUICallback('getZones', function(data, cb) QBCore.Functions.TriggerCallback('qb-jobcreator:server:getZones', function(list) cb(list or {}) end, data.job) end)
 RegisterNUICallback('createZone', function(data, cb) TriggerServerEvent('qb-jobcreator:server:createZone', data); cb({ ok = true }) end)
 RegisterNUICallback('deleteZone', function(data, cb) TriggerServerEvent('qb-jobcreator:server:deleteZone', data.id); cb({ ok = true }) end)
-RegisterNUICallback('getCoords', function(_, cb) local p = GetEntityCoords(PlayerPedId()); cb({ x = p.x, y = p.y, z = p.z }) end)
+RegisterNUICallback('getCoords', function(_, cb)
+  local ped = PlayerPedId()
+  local p = GetEntityCoords(ped)
+  local heading = GetEntityHeading(ped)
+  cb({ x = p.x, y = p.y, z = p.z, w = heading })
+end)
 
 RegisterNUICallback('getCraftingTable', function(data, cb)
   QBCore.Functions.TriggerCallback('qb-jobcreator:server:getCraftingTable', function(list)


### PR DESCRIPTION
## Summary
- include player heading in `getCoords` callback
- confirm teleport section processes heading (`tpw`) field

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4cbc819188326b1ad9af247a9b1be