### PR TITLE
Always show teleport option without destinations

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -408,8 +408,8 @@ local function addTargetForZone(z)
         opts = {
           {
             label = 'Teletransportar', icon = 'fa-solid fa-person-arrow-up-from-line',
-            canInteract = function() return false end,
-            action = function() QBCore.Functions.Notify('Destino no configurado.', 'error') end
+            canInteract = function() return true end,
+            action = function() QBCore.Functions.Notify('Destino no configurado', 'error') end
           }
         }
       else
@@ -432,7 +432,7 @@ local function addTargetForZone(z)
           canInteract = function() return canUseZone(z, false) end,
           action = function()
             if #dests == 0 then
-              QBCore.Functions.Notify('Destino no configurado.', 'error')
+              QBCore.Functions.Notify('Destino no configurado', 'error')
               return
             end
             if GetResourceState('qb-menu') == 'started' and #dests > 1 then


### PR DESCRIPTION
## Summary
- Always display teleport option even when no destinations are configured
- Notify players when teleport lacks destinations

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4cca282e883268a42cf224092b5c7