### PR TITLE
refactor: tighten zone radius interactions

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -205,8 +205,8 @@ local function addTargetForZone(z)
   if not Config.Integrations.UseQbTarget then return end
   local name = uniqueZoneName(('jc_%s_%s_%s'):format(z.ztype, z.job, z.id))
   local radius = tonumber(z.radius) or Config.Zone.DefaultRadius or 2.0
-  local size = (radius + 0.5) * 2.0
-  local distance = radius + 1.0
+  local size = radius * 2.0
+  local distance = radius
   local opts = {}
   local usingTarget = GetResourceState('qb-target') == 'started'
   if not usingTarget then


### PR DESCRIPTION
## Summary
- remove extra buffer from `qb-jobcreator` target zone size and distance so interactions occur closer to the circle radius

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4ce42fb8483269fa83648ab26cc9a