### PR TITLE
feat: warn when qb-target missing

### DIFF
--- a/qb-jobcreator/client/zones.lua
+++ b/qb-jobcreator/client/zones.lua
@@ -211,6 +211,7 @@ local function addTargetForZone(z)
   local usingTarget = GetResourceState('qb-target') == 'started'
   if not usingTarget then
     print(('[qb-jobcreator] qb-target no iniciado, usando fallback para %s'):format(name))
+    QBCore.Functions.Notify('qb-target no iniciado, usando fallback', 'error')
   end
 
   if z.ztype == 'boss' then

--- a/qb-jobcreator/fxmanifest.lua
+++ b/qb-jobcreator/fxmanifest.lua
@@ -19,6 +19,7 @@ files {
 }
 
 dependencies {
+  'qb-target',
   'qb-core',
   'qb-menu',      -- opcional (atajo F6)
   'qb-input'      -- opcional (atajos)


### PR DESCRIPTION
## Summary
- warn admins with notification when qb-target isn't started
- ensure qb-target resource starts before qb-jobcreator

## Testing
- `lua5.4 qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua && lua5.4 qb-jobcreator/tests/sanitize_shop_items_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4dd7ad77c8326aebb61a841f9b43f