### PR TITLE
Allow teleport usage when job not specified

### DIFF
--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -1186,7 +1186,9 @@ RegisterNetEvent('qb-jobcreator:server:teleport', function(zoneId, fromIdx, toId
   if not Player or not Player.PlayerData then return end
   local jd = Player.PlayerData.job or {}
   local cid = Player.PlayerData.citizenid
-  if jd.name ~= zone.job and not Multi_Has(cid, zone.job) then return end
+  if zone.job and zone.job ~= '' then
+    if jd.name ~= zone.job and not Multi_Has(cid, zone.job) then return end
+  end
 
   local d = zone.data or {}
   local to = d.to

--- a/qb-jobcreator/tests/teleport_job_validation_test.lua
+++ b/qb-jobcreator/tests/teleport_job_validation_test.lua
@@ -1,0 +1,54 @@
+local file = assert(io.open("qb-jobcreator/server/main.lua", "r"))
+local src = file:read("*a")
+file:close()
+
+local body = src:match("RegisterNetEvent%('qb%-jobcreator:server:teleport', function%([^%)]*%)(.-)\nend%)")
+assert(body, "Teleport event not found")
+
+local teleport = load("return function(zoneId, fromIdx, toIdx)\n" .. body .. "\nend")()
+
+local function makeVec(x, y, z)
+  local v = { x = x, y = y, z = z }
+  return setmetatable(v, {
+    __sub = function(a, b) return makeVec(a.x - b.x, a.y - b.y, a.z - b.z) end,
+    __len = function(a) return math.sqrt(a.x * a.x + a.y * a.y + a.z * a.z) end
+  })
+end
+
+vector3 = makeVec
+GetEntityCoords = function(...) calledGetEntityCoords = true return makeVec(0, 0, 0) end
+GetPlayerPed = function(_) return 0 end
+SetEntityCoords = function(...) end
+SetEntityHeading = function(...) end
+
+Multi_Has = function(cid, job) return false end
+
+local zone
+findZoneById = function(id) return zone end
+
+local player
+QBCore = { Functions = { GetPlayer = function(_) return player end } }
+
+-- Case 1: job required, player has different job
+zone = { id = 1, ztype = 'teleport', job = 'required', coords = { x = 0, y = 0, z = 0 }, radius = 2.0, data = { to = { { x = 1, y = 1, z = 1 } } } }
+player = { PlayerData = { job = { name = 'other' }, citizenid = 'cid1' } }
+calledGetEntityCoords = false
+teleport(1, 0, 1)
+assert(not calledGetEntityCoords, 'Unauthorized teleport should not proceed')
+
+-- Case 2: job required, player has correct job
+zone.job = 'required'
+player.PlayerData.job.name = 'required'
+calledGetEntityCoords = false
+teleport(1, 0, 1)
+assert(calledGetEntityCoords, 'Authorized teleport should proceed')
+
+-- Case 3: job not specified, any player allowed
+zone.job = ''
+player.PlayerData.job.name = 'other'
+calledGetEntityCoords = false
+teleport(1, 0, 1)
+assert(calledGetEntityCoords, 'Teleport without job restriction should be allowed')
+
+print('Teleport job validation test passed')
+


### PR DESCRIPTION
## Summary
- Only enforce job check on teleport zones when a job is configured
- Add tests verifying job-restricted and unrestricted teleports

## Testing
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua && lua qb-jobcreator/tests/sanitize_shop_items_test.lua && lua qb-jobcreator/tests/teleport_job_validation_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4df1d3df4832685e5ccc09a52810f