### PR TITLE
Support job field for teleport zones

### DIFF
--- a/qb-jobcreator/client/main.lua
+++ b/qb-jobcreator/client/main.lua
@@ -234,7 +234,7 @@ end)
 
 -- Guardar data de una zona (para “vehículos por rango”)
 RegisterNUICallback('updateZone', function(data, cb)
-  TriggerServerEvent('qb-jobcreator:server:updateZone', tonumber(data.id), data.data, data.label, data.radius, data.coords)
+  TriggerServerEvent('qb-jobcreator:server:updateZone', tonumber(data.id), data.data, data.label, data.radius, data.coords, data.job)
   cb({ ok = true })
 end)
 

--- a/qb-jobcreator/server/db.lua
+++ b/qb-jobcreator/server/db.lua
@@ -118,6 +118,7 @@ function DB.UpdateZone(id, fields)
   if fields.radius  ~= nil then sets[#sets+1] = 'radius=?';  params[#params+1] = fields.radius end
   if fields.coords  ~= nil then sets[#sets+1] = 'coords=?';  params[#params+1] = json.encode(fields.coords) end
   if fields.data    ~= nil then sets[#sets+1] = 'data=?';    params[#params+1] = json.encode(fields.data) end
+  if fields.job     ~= nil then sets[#sets+1] = 'job=?';     params[#params+1] = fields.job end
   if #sets == 0 then return end
   params[#params+1] = id
   MySQL.query.await(('UPDATE jobcreator_zones SET %s WHERE id=?'):format(table.concat(sets, ',')), params)

--- a/qb-jobcreator/server/main.lua
+++ b/qb-jobcreator/server/main.lua
@@ -808,10 +808,11 @@ RegisterNetEvent('qb-jobcreator:server:wash', function(job, amount)
 end)
 
 -- Actualizar zona (guardar 'data', label/radius/coords opcional)
-RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, radius, coords)
-  local src = source; local job; local ztype; local old
-  for _, z in ipairs(Runtime.Zones) do if z.id == id then job = z.job ztype = z.ztype old = z break end end
-  if not allowAdminOrBoss(src, job or '') then return end
+RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, radius, coords, job)
+  local src = source; local oldJob; local ztype; local old
+  for _, z in ipairs(Runtime.Zones) do if z.id == id then oldJob = z.job ztype = z.ztype old = z break end end
+  if not allowAdminOrBoss(src, oldJob or '') then return end
+  if type(job) ~= 'string' then job = oldJob end
   if type(data) == 'table' then
     if ztype == 'shop' then
       data.items = SanitizeShopItems(data.items)
@@ -843,7 +844,7 @@ RegisterNetEvent('qb-jobcreator:server:updateZone', function(id, data, label, ra
     data.clearArea = data.clearArea and true or false
     if data.clearRadius ~= nil then data.clearRadius = tonumber(data.clearRadius) or Config.Zone.ClearRadius end
   end
-  if DB.UpdateZone then DB.UpdateZone(id, { data = data, label = label, radius = radius, coords = coords }) end
+  if DB.UpdateZone then DB.UpdateZone(id, { data = data, label = label, radius = radius, coords = coords, job = job }) end
   local row = MySQL.query.await('SELECT * FROM jobcreator_zones WHERE id = ?', { id })
   local r = row and row[1]
   if r then

--- a/qb-jobcreator/web/app.js
+++ b/qb-jobcreator/web/app.js
@@ -51,8 +51,9 @@ const App = (() => {
     };
   }
 
-  function renderTeleportSection(box, items = []) {
+  function renderTeleportSection(box, items = [], job = '') {
     box.innerHTML = `
+      <div class="row"><input id="zjob" class="input" placeholder="Job" value="${job || ''}"/></div>
       <div id="tp-items"></div>
       <div class="row"><button class="btn" id="addTP">+ Destino</button></div>`;
     const wrap = box.querySelector('#tp-items');
@@ -771,7 +772,7 @@ const App = (() => {
         const cr = Number(document.getElementById('zclearrad')?.value || 0);
         data.clearArea = cr > 0;
         data.clearRadius = cr;
-        post('updateZone', { id, data, label: document.getElementById('zlabel').value, radius: Number(document.getElementById('zrad').value) || 2.0, coords }).then(() => { closeModal(); load(); });
+        post('updateZone', { id, data, label: document.getElementById('zlabel').value, radius: Number(document.getElementById('zrad').value) || 2.0, coords, job: document.getElementById('zjob')?.value || '' }).then(() => { closeModal(); load(); });
       });
 
       document.getElementById('zcoords').onclick = () => {
@@ -834,7 +835,7 @@ const App = (() => {
           box.innerHTML = row(inp('zname','Nombre DJ','', d.name || '') + inp('zrange','Radio','20', d.range || d.distance || '')) +
                           row(inp('zurl','YouTube/URL','https://...', d.url || '') + inp('zvol','Volumen (0-1)','0.5', d.volume || ''));
         } else if (t === 'teleport') {
-          renderTeleportSection(box, d.to || []);
+          renderTeleportSection(box, d.to || [], zone.job);
         } else {
           box.innerHTML = '';
         }
@@ -912,7 +913,7 @@ const App = (() => {
           data.clearArea = cr > 0;
           data.clearRadius = cr;
           const z = {
-            job: state.jd.job,
+            job: document.getElementById('zjob')?.value || '',
             ztype: t,
             label: document.getElementById('zlabel').value,
             radius: Number(document.getElementById('zrad').value) || 2.0,
@@ -974,7 +975,7 @@ const App = (() => {
         box.innerHTML = row(inp('zname','Nombre DJ','') + inp('zrange','Radio','20')) +
                         row(inp('zurl','YouTube/URL','https://...') + inp('zvol','Volumen (0-1)','0.5'));
       } else if (t === 'teleport') {
-        renderTeleportSection(box, []);
+        renderTeleportSection(box, [], state.jd.job);
       } else {
         box.innerHTML = '';
       }


### PR DESCRIPTION
## Summary
- allow teleport zones to specify a job via new `zjob` input
- transmit selected job when creating or updating zones
- persist zone job changes in server runtime and DB

## Testing
- `lua qb-jobcreator/tests/sanitize_shop_items_test.lua`
- `lua qb-jobcreator/tests/collect_crafting_data_allowed_categories_test.lua`
- `lua qb-jobcreator/tests/teleport_job_validation_test.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b4ed80aeac8326a45e03743f4acbd9