### PR TITLE
Remove owner check for cleanup vehicles

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -110,10 +110,6 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
       -- No borrar si hay alguien a bordo
       if isAnySeatOccupied(veh) then goto continue end
 
-      -- Solo el owner de la entidad elimina para evitar duplicados
-      local owner = NetworkGetEntityOwner(veh)
-      if owner ~= PlayerId() then goto continue end
-
       -- Intentar borrar
       if tryDeleteVehicle(veh) then
         removed = removed + 1


### PR DESCRIPTION
## Summary
- Remove NetworkGetEntityOwner gate in cleanup to delete empty vehicles after network control is requested

## Testing
- `luacheck autotow/client.lua` (returns warnings only)


------
https://chatgpt.com/codex/tasks/task_e_68b4f8802e688326a194a9003e6ab8ea