### PR TITLE
feat: add immediate tow cleanup command

### DIFF
--- a/autotow/config.lua
+++ b/autotow/config.lua
@@ -26,10 +26,12 @@ Config.BlacklistedClasses = {}
 -- Comandos
 Config.CommandCancel = 'towcancel'
 Config.CommandTrigger = 'towtrigger' -- disparo manual
+Config.CommandImmediate = 'towclean' -- limpieza inmediata
 
 -- Permisos ACE (usa add_ace en server.cfg)
 Config.AceCancel  = 'invictus.tow.cancel'
 Config.AceTrigger = 'invictus.tow.trigger'
+Config.AceImmediate = 'invictus.tow.immediate'
 
 -- Mensajes de alerta
 Config.AlertTitle  = 'LIMPIEZA DE VEHÍCULOS'

--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -161,6 +161,31 @@ RegisterCommand(Config.CommandTrigger, function(src)
   startCleanupCycle(true)
 end)
 
+-- Limpieza inmediata sin avisos ni temporizadores
+local function immediateCleanup()
+  cleanupState.token = cleanupState.token + 1
+  TriggerClientEvent('invictus_tow:client:doCleanup', -1, {
+    minDist = Config.MinDistanceFromAnyPlayer,
+    skipEmergency = Config.SkipEmergencyVehicles,
+    skipBA = Config.SkipBoatsAndAircraft,
+    blModels = Config.BlacklistedModels,
+    blClasses = Config.BlacklistedClasses,
+    debug = Config.Debug
+  }, cleanupState.token)
+  print(('^2[%s]^7 Limpieza inmediata ejecutada.'):format(Config.ResourceName))
+end
+
+-- Comando: limpieza inmediata
+RegisterCommand(Config.CommandImmediate, function(src)
+  if src and src > 0 then
+    if not IsPlayerAceAllowed(src, Config.AceImmediate) then
+      TriggerClientEvent('chat:addMessage', src, { args = {'TOW', '^1No tienes permiso para ejecutar.'} })
+      return
+    end
+  end
+  immediateCleanup()
+end)
+
 -- Bucle automático
 CreateThread(function()
   Wait(2500)


### PR DESCRIPTION
## Summary
- add `towclean` admin command and permission for immediate vehicle cleanup
- implement server-side handler to remove vehicles instantly without notifications or countdown

## Testing
- `luacheck autotow`

------
https://chatgpt.com/codex/tasks/task_e_68b50260e1948326b9ec10d89ebad440