### PR TITLE
Improve vehicle deletion control

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -62,6 +62,22 @@ local function tryDeleteVehicle(veh)
       attempts = attempts + 1
       Wait(25)
     end
+    if not NetworkHasControlOfEntity(veh) then
+      local netId = NetworkGetNetworkIdFromEntity(veh)
+      NetworkRequestControlOfNetworkId(netId)
+      attempts = 0
+      while attempts < 20 and not NetworkHasControlOfEntity(veh) do
+        attempts = attempts + 1
+        Wait(25)
+      end
+      if not NetworkHasControlOfEntity(veh) then
+        if Config.Debug then
+          dprint(('No se pudo tomar control del vehículo %s; delegando al servidor'):format(netId))
+        end
+        TriggerServerEvent('invictus_tow:server:deleteVehicle', netId)
+        return true
+      end
+    end
   end
 
   SetEntityAsMissionEntity(veh, true, true)

--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -128,6 +128,19 @@ RegisterNetEvent('invictus_tow:server:report', function(token, deletedCount)
   end
 end)
 
+RegisterNetEvent('invictus_tow:server:deleteVehicle', function(netId)
+  local veh = NetworkGetEntityFromNetworkId(netId)
+  if DoesEntityExist(veh) then
+    SetEntityAsMissionEntity(veh, true, true)
+    DeleteEntity(veh)
+    if Config.Debug then
+      debugPrint(('Vehículo %s eliminado por servidor'):format(netId))
+    end
+  elseif Config.Debug then
+    debugPrint(('No se pudo eliminar el vehículo %s: no existe'):format(netId))
+  end
+end)
+
 -- Cancelar ciclo
 local function cancelCleanup(src)
   if not cleanupState.active then


### PR DESCRIPTION
## Summary
- Retry vehicle control with network ID and delegate deletion to server if still unsuccessful
- Add server-side vehicle deletion event with debug logging

## Testing
- `luacheck autotow`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5037590f8832691f3a95b22c3ae3f