### PR TITLE
Use GetActivePlayers for distance checks in AutoTow

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -135,9 +135,10 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
       -- Distancia mínima a jugadores
       if cfg.minDist and cfg.minDist > 0 then
         local vehCoords = GetEntityCoords(veh)
-        local players = GetPlayers()
+        local players = GetActivePlayers()
         for i = 1, #players do
-          local ped = GetPlayerPed(players[i])
+          local playerId = players[i]
+          local ped = GetPlayerPed(playerId)
           local pCoords = GetEntityCoords(ped)
           if #(vehCoords - pCoords) < cfg.minDist then
             goto continue


### PR DESCRIPTION
## Summary
- Replace deprecated GetPlayers call with GetActivePlayers in vehicle cleanup
- Iterate over active players to obtain ped coordinates

## Testing
- `luac -p autotow/client.lua`
- `lua test snippet` (Config.MinDistanceFromAnyPlayer > 0; ensure no errors)

------
https://chatgpt.com/codex/tasks/task_e_68b51659fa008326bd0bdc4db23e03d3