### PR TITLE
Ensure autotow deletion counts after server confirmation

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -210,17 +210,23 @@ RegisterNetEvent('invictus_tow:server:report', function(token, deletedCount)
   end
 end)
 
-RegisterNetEvent('invictus_tow:server:deleteVehicle', function(netId)
+RegisterNetEvent('invictus_tow:server:deleteVehicle', function(netId, token)
+  local src = source
   local veh = NetworkGetEntityFromNetworkId(netId)
+  local success = false
   if DoesEntityExist(veh) then
     SetEntityAsMissionEntity(veh, true, true)
     DeleteEntity(veh)
+    success = not DoesEntityExist(veh)
     if Config.Debug then
       debugPrint(('Vehículo %s eliminado por servidor'):format(netId))
     end
-  elseif Config.Debug then
-    debugPrint(('No se pudo eliminar el vehículo %s: no existe'):format(netId))
+  else
+    if Config.Debug then
+      debugPrint(('No se pudo eliminar el vehículo %s: no existe'):format(netId))
+    end
   end
+  TriggerClientEvent('invictus_tow:client:deleteResult', src, token, success)
 end)
 
 -- Cancelar ciclo


### PR DESCRIPTION
## Summary
- wait for server confirmation before counting deleted vehicles
- send deletion result back to clients from server
- track pending deletions and include them in cleanup report

## Testing
- `luacheck autotow 2>&1 | head -n 20`
- `luacheck autotow/server.lua 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b51f94c81883268e3cba3697195d51