### PR TITLE
Notify clients of server vehicle deletions

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -123,6 +123,17 @@ RegisterNetEvent('invictus_tow:client:deleteResult', function(token, success)
   cleanupState.pending = math.max(0, cleanupState.pending - 1)
 end)
 
+RegisterNetEvent('invictus_tow:client:vehicleRemoved', function(netId)
+  local veh = NetworkGetEntityFromNetworkId(netId)
+  if DoesEntityExist(veh) then
+    SetEntityAsMissionEntity(veh, false, false)
+    DeleteVehicle(veh)
+    if DoesEntityExist(veh) then
+      DeleteEntity(veh)
+    end
+  end
+end)
+
 -- Ejecución de limpieza
 RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
   cleanupState.removed = 0

--- a/autotow/config.lua
+++ b/autotow/config.lua
@@ -13,6 +13,9 @@ Config.AlertDuration = 20
 -- Distancia mínima a cualquier jugador para poder borrar un vehículo
 Config.MinDistanceFromAnyPlayer = 0
 
+-- Distancia máxima para notificar a jugadores cercanos cuando el servidor elimina un vehículo
+Config.RemoveNotifyRange = 300.0
+
 -- Exclusiones / filtros
 Config.SkipEmergencyVehicles = false     -- Clase 18
 Config.SkipBoatsAndAircraft = false      -- 14=boats, 15=heli, 16=planes, 21=trains

--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -59,6 +59,10 @@ local DeleteEntity = DeleteEntity or function(entity)
   return Citizen.InvokeNative(0x7D9EFB7AD0A3BED7, entity)
 end
 
+local NetworkGetNetworkIdFromEntity = NetworkGetNetworkIdFromEntity or function(entity)
+  return Citizen.InvokeNative(0xA11700682F3AD45C, entity)
+end
+
 local GetPlayerPed = GetPlayerPed or function(player)
   return Citizen.InvokeNative(0x6E31E99359A9B316, player)
 end
@@ -82,9 +86,23 @@ local function cleanupServerVehicles(cfg)
 
       if not model or model == 0 then
         SetEntityAsMissionEntity(veh, true, true)
+        local vehCoords = GetEntityCoords(veh)
+        local netId = NetworkGetNetworkIdFromEntity(veh)
         DeleteEntity(veh)
         if not DoesEntityExist(veh) then
           removed = removed + 1
+          local range = Config.RemoveNotifyRange or 0
+          if range > 0 then
+            local players = GetPlayers()
+            for i = 1, #players do
+              local playerId = tonumber(players[i])
+              local ped = GetPlayerPed(playerId)
+              local pCoords = GetEntityCoords(ped)
+              if #(vehCoords - pCoords) < range then
+                TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+              end
+            end
+          end
         end
         goto continue
       end
@@ -111,9 +129,23 @@ local function cleanupServerVehicles(cfg)
       -- if isAnySeatOccupied(veh) then goto continue end
 
       SetEntityAsMissionEntity(veh, true, true)
+      local vehCoords = GetEntityCoords(veh)
+      local netId = NetworkGetNetworkIdFromEntity(veh)
       DeleteEntity(veh)
       if not DoesEntityExist(veh) then
         removed = removed + 1
+        local range = Config.RemoveNotifyRange or 0
+        if range > 0 then
+          local players = GetPlayers()
+          for i = 1, #players do
+            local playerId = tonumber(players[i])
+            local ped = GetPlayerPed(playerId)
+            local pCoords = GetEntityCoords(ped)
+            if #(vehCoords - pCoords) < range then
+              TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+            end
+          end
+        end
       end
     end
     ::continue::


### PR DESCRIPTION
## Summary
- notify nearby players when server cleanup deletes a vehicle
- add distance-based config for removal notifications
- ensure clients remove lingering vehicles when server deletes them

## Testing
- `luacheck autotow`

------
https://chatgpt.com/codex/tasks/task_e_68b5e329c31c83268a8e724b9ba775e6