### PR TITLE
Guard vehicle seat check against invalid passenger data

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -69,6 +69,10 @@ end
 
 local function isAnySeatOccupied(veh)
   local max = GetVehicleMaxNumberOfPassengers(veh)
+  if type(max) ~= "number" then
+    debugPrint(('Unexpected max passenger value %s for vehicle %s'):format(tostring(max), veh))
+    return true
+  end
   for seat = -1, max do
     if not IsVehicleSeatFree(veh, seat) then
       return true


### PR DESCRIPTION
## Summary
- Avoid deleting vehicles when `GetVehicleMaxNumberOfPassengers` returns non-numeric by assuming seats occupied
- Log unexpected values for easier debugging

## Testing
- `luac -p autotow/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b5f199e2508326aaadf8784fe8582b