### PR TITLE
chore: share seat check between client and server

### DIFF
--- a/autotow/README.md
+++ b/autotow/README.md
@@ -6,6 +6,7 @@ Automated Tow Script for FiveM – **QBCore** compatible. Elimina vehículos des
 - ⏱️ Limpieza automática cada `Config.IntervalMinutes` minutos
 - 📣 Notificaciones en pantalla con ox_lib
 - 👥 Verificación de **todos los asientos** antes de borrar un vehículo
+- 🔁 Rutina de verificación compartida entre cliente y servidor para garantizar el mismo filtrado
 - 🧯 Filtros: distancia a jugadores, clases/vehículos en blacklist, emergencia/boats/aircraft opcional
 - 🛡️ Permisos **ACE** para cancelar o disparar manualmente
 - 🧩 100% configurable desde `config.lua`

--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -4,6 +4,7 @@ local function dprint(msg)
   end
 end
 
+-- Seat occupancy check lives in seat_check.lua and is shared with server.lua
 -- Estado de la limpieza actual
 local cleanupState = {
   removed = 0,
@@ -44,16 +45,6 @@ local function isClassBlacklisted(class, list)
   if not list then return false end
   for i=1, #list do
     if class == list[i] then return true end
-  end
-  return false
-end
-
-local function isAnySeatOccupied(veh)
-  local max = GetVehicleMaxNumberOfPassengers(veh)
-  for seat = -1, max do
-    if not IsVehicleSeatFree(veh, seat) then
-      return true
-    end
   end
   return false
 end
@@ -178,7 +169,7 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
       end
 
       -- No borrar si hay alguien a bordo
-      if isAnySeatOccupied(veh) then goto continue end
+      if isAnySeatOccupied(veh, dprint) then goto continue end
 
       -- Intentar borrar
       local res = tryDeleteVehicle(veh, token)

--- a/autotow/fxmanifest.lua
+++ b/autotow/fxmanifest.lua
@@ -11,7 +11,8 @@ version '1.0.0'
 
 shared_scripts {
   '@ox_lib/init.lua',
-  'config.lua'
+  'config.lua',
+  'seat_check.lua'
 }
 
 client_scripts {

--- a/autotow/seat_check.lua
+++ b/autotow/seat_check.lua
@@ -1,0 +1,46 @@
+-- Shared seat occupancy check to ensure client and server filter vehicles identically.
+-- This routine is used in both local and server cleanups to avoid future divergence.
+
+GetVehicleMaxNumberOfPassengers = GetVehicleMaxNumberOfPassengers or function(vehicle)
+  return Citizen.InvokeNative(0xA7C4F2C6E744A1E8, vehicle)
+end
+
+GetVehicleNumberOfPassengers = GetVehicleNumberOfPassengers or function(vehicle)
+  return Citizen.InvokeNative(0x24CB213773B00F79, vehicle)
+end
+
+IsVehicleSeatFree = IsVehicleSeatFree or function(vehicle, seatIndex)
+  return Citizen.InvokeNative(0x22AC59A870E6A669, vehicle, seatIndex)
+end
+
+function isAnySeatOccupied(veh, logFn)
+  local max = GetVehicleMaxNumberOfPassengers(veh)
+  if type(max) ~= "number" or max < -1 then
+    if logFn then
+      logFn(('Unexpected max passenger value %s for vehicle %s'):format(tostring(max), veh))
+    end
+    max = GetVehicleNumberOfPassengers(veh)
+    if type(max) ~= "number" or max < -1 then
+      max = 0
+    end
+  end
+
+  if max > 7 then max = 7 end
+
+  for seat = -1, max do
+    local seatFree = IsVehicleSeatFree and IsVehicleSeatFree(veh, seat)
+    if type(seatFree) ~= "boolean" then
+      if logFn then
+        logFn(('Unexpected seat state %s for vehicle %s seat %s'):format(tostring(seatFree), veh, seat))
+      end
+      seatFree = true
+    end
+    if not seatFree then return true end
+  end
+
+  return false
+end
+
+return {
+  isAnySeatOccupied = isAnySeatOccupied
+}


### PR DESCRIPTION
## Summary
- move seat occupancy check into shared module used by client and server
- document shared routine to avoid future divergence

## Testing
- `lua - <<'EOF' ... EOF`


------
https://chatgpt.com/codex/tasks/task_e_68b5fea1fdf4832687e390184990e494