### PR TITLE
Ensure auto tow skips occupied vehicles

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -137,11 +137,13 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
 
       -- Borrar si el modelo es 0 o nil
       if not model or model == 0 then
-        local res = tryDeleteVehicle(veh, token)
-        if res then
-          cleanupState.removed = cleanupState.removed + 1
-        elseif res == nil then
-          cleanupState.pending = cleanupState.pending + 1
+        if not isAnySeatOccupied(veh, dprint) then
+          local res = tryDeleteVehicle(veh, token)
+          if res then
+            cleanupState.removed = cleanupState.removed + 1
+          elseif res == nil then
+            cleanupState.pending = cleanupState.pending + 1
+          end
         end
         goto continue
       end
@@ -168,15 +170,13 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
         end
       end
 
-      -- No borrar si hay alguien a bordo
-      if isAnySeatOccupied(veh, dprint) then goto continue end
-
-      -- Intentar borrar
-      local res = tryDeleteVehicle(veh, token)
-      if res then
-        cleanupState.removed = cleanupState.removed + 1
-      elseif res == nil then
-        cleanupState.pending = cleanupState.pending + 1
+      if not isAnySeatOccupied(veh, dprint) then
+        local res = tryDeleteVehicle(veh, token)
+        if res then
+          cleanupState.removed = cleanupState.removed + 1
+        elseif res == nil then
+          cleanupState.pending = cleanupState.pending + 1
+        end
       end
     end
     ::continue::

--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -65,25 +65,26 @@ local function cleanupServerVehicles(cfg)
   local removed = 0
   for _, veh in ipairs(GetAllVehicles()) do
     if DoesEntityExist(veh) then
-      if isAnySeatOccupied(veh, debugPrint) then goto continue end
       local model = GetEntityModel(veh)
 
       if not model or model == 0 then
-        SetEntityAsMissionEntity(veh, true, true)
-        local vehCoords = GetEntityCoords(veh)
-        local netId = NetworkGetNetworkIdFromEntity(veh)
-        DeleteEntity(veh)
-        if not DoesEntityExist(veh) then
-          removed = removed + 1
-          local range = Config.RemoveNotifyRange or 0
-          if range > 0 then
-            local players = GetPlayers()
-            for i = 1, #players do
-              local playerId = tonumber(players[i])
-              local ped = GetPlayerPed(playerId)
-              local pCoords = GetEntityCoords(ped)
-              if #(vehCoords - pCoords) < range then
-                TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+        if not isAnySeatOccupied(veh, debugPrint) then
+          SetEntityAsMissionEntity(veh, true, true)
+          local vehCoords = GetEntityCoords(veh)
+          local netId = NetworkGetNetworkIdFromEntity(veh)
+          DeleteEntity(veh)
+          if not DoesEntityExist(veh) then
+            removed = removed + 1
+            local range = Config.RemoveNotifyRange or 0
+            if range > 0 then
+              local players = GetPlayers()
+              for i = 1, #players do
+                local playerId = tonumber(players[i])
+                local ped = GetPlayerPed(playerId)
+                local pCoords = GetEntityCoords(ped)
+                if #(vehCoords - pCoords) < range then
+                  TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+                end
               end
             end
           end
@@ -110,21 +111,23 @@ local function cleanupServerVehicles(cfg)
       --   end
       -- end
 
-      SetEntityAsMissionEntity(veh, true, true)
-      local vehCoords = GetEntityCoords(veh)
-      local netId = NetworkGetNetworkIdFromEntity(veh)
-      DeleteEntity(veh)
-      if not DoesEntityExist(veh) then
-        removed = removed + 1
-        local range = Config.RemoveNotifyRange or 0
-        if range > 0 then
-          local players = GetPlayers()
-          for i = 1, #players do
-            local playerId = tonumber(players[i])
-            local ped = GetPlayerPed(playerId)
-            local pCoords = GetEntityCoords(ped)
-            if #(vehCoords - pCoords) < range then
-              TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+      if not isAnySeatOccupied(veh, debugPrint) then
+        SetEntityAsMissionEntity(veh, true, true)
+        local vehCoords = GetEntityCoords(veh)
+        local netId = NetworkGetNetworkIdFromEntity(veh)
+        DeleteEntity(veh)
+        if not DoesEntityExist(veh) then
+          removed = removed + 1
+          local range = Config.RemoveNotifyRange or 0
+          if range > 0 then
+            local players = GetPlayers()
+            for i = 1, #players do
+              local playerId = tonumber(players[i])
+              local ped = GetPlayerPed(playerId)
+              local pCoords = GetEntityCoords(ped)
+              if #(vehCoords - pCoords) < range then
+                TriggerClientEvent('invictus_tow:client:vehicleRemoved', playerId, netId)
+              end
             end
           end
         end


### PR DESCRIPTION
## Summary
- Guard server-side vehicle deletions with `isAnySeatOccupied`
- Prevent client cleanup from deleting vehicles with occupants

## Testing
- `luac -p autotow/server.lua autotow/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b6093969408326b76e3c6505993208