### PR TITLE
Check vehicle seats before cleaning up vehicles

### DIFF
--- a/autotow/client.lua
+++ b/autotow/client.lua
@@ -146,6 +146,8 @@ RegisterNetEvent('invictus_tow:client:doCleanup', function(cfg, token)
 
       -- Borrar si el modelo es 0 o nil
       if not model or model == 0 then
+        -- Saltar si hay alguien en cualquier asiento
+        if isAnySeatOccupied(veh) then goto continue end
         local res = tryDeleteVehicle(veh, token)
         if res then
           cleanupState.removed = cleanupState.removed + 1


### PR DESCRIPTION
## Summary
- skip cleanup deletion when any vehicle seat is occupied during model check

## Testing
- `luac -p autotow/client.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b60e12300c832682c77e5ccf872c36