### PR TITLE
Preserve occupied vehicles during cleanup

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -85,6 +85,7 @@ local function cleanupServerVehicles(cfg)
       local model = GetEntityModel(veh)
 
       if not model or model == 0 then
+        if isAnySeatOccupied(veh) then goto continue end
         SetEntityAsMissionEntity(veh, true, true)
         local vehCoords = GetEntityCoords(veh)
         local netId = NetworkGetNetworkIdFromEntity(veh)
@@ -126,7 +127,7 @@ local function cleanupServerVehicles(cfg)
       --   end
       -- end
 
-      -- if isAnySeatOccupied(veh) then goto continue end
+      if isAnySeatOccupied(veh) then goto continue end
 
       SetEntityAsMissionEntity(veh, true, true)
       local vehCoords = GetEntityCoords(veh)


### PR DESCRIPTION
## Summary
- ensure cleanup skips vehicles with occupants, even when model data is invalid

## Testing
- `luac -p autotow/server.lua`

------
https://chatgpt.com/codex/tasks/task_e_68b61087d2ac8326a185e592f88aa35d