### PR TITLE
Validate seat count before arithmetic in seat check

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -73,12 +73,20 @@ end
 
 local function isAnySeatOccupied(veh)
   local max = GetVehicleMaxNumberOfPassengers(veh)
+
   if type(max) ~= 'number' or max < 0 then
     local model = GetEntityModel(veh)
-    max = GetVehicleModelNumberOfSeats(model) - 2
+    local seats = GetVehicleModelNumberOfSeats(model)
+
+    if type(seats) == 'number' and seats > 0 then
+      max = seats - 2      -- iterate all valid seats
+    else
+      max = -1             -- fall back to driver seat only
+    end
   else
     max = max - 1
   end
+
   for seat = -1, max do
     if not IsVehicleSeatFree(veh, seat) then
       return true


### PR DESCRIPTION
## Summary
- avoid boolean arithmetic in `isAnySeatOccupied` by verifying seat count before subtracting

## Testing
- `luacheck autotow/server.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b614ca7f9c8326bfb444980ababbe5