### PR TITLE
feat(autotow): guard network ID retrieval

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -113,12 +113,15 @@ local function cleanupServerVehicles(cfg)
         if isAnySeatOccupied(veh) then goto continue end
         SetEntityAsMissionEntity(veh, true, true)
         local vehCoords = GetEntityCoords(veh)
-        local netId = NetworkGetNetworkIdFromEntity(veh)
+        local netId = nil
+        if DoesEntityExist(veh) and NetworkGetEntityIsNetworked(veh) then
+          netId = NetworkGetNetworkIdFromEntity(veh)
+        end
         DeleteEntity(veh)
         if not DoesEntityExist(veh) then
           removed = removed + 1
           local range = Config.RemoveNotifyRange or 0
-          if range > 0 then
+          if range > 0 and netId then
             local players = GetPlayers()
             for i = 1, #players do
               local playerId = tonumber(players[i])
@@ -156,12 +159,15 @@ local function cleanupServerVehicles(cfg)
 
       SetEntityAsMissionEntity(veh, true, true)
       local vehCoords = GetEntityCoords(veh)
-      local netId = NetworkGetNetworkIdFromEntity(veh)
+      local netId = nil
+      if DoesEntityExist(veh) and NetworkGetEntityIsNetworked(veh) then
+        netId = NetworkGetNetworkIdFromEntity(veh)
+      end
       DeleteEntity(veh)
       if not DoesEntityExist(veh) then
         removed = removed + 1
         local range = Config.RemoveNotifyRange or 0
-        if range > 0 then
+        if range > 0 and netId then
           local players = GetPlayers()
           for i = 1, #players do
             local playerId = tonumber(players[i])


### PR DESCRIPTION
## Summary
- ensure vehicle cleanup only retrieves network IDs for existing networked entities
- send removal notifications only when a valid netId is obtained

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `python -m pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b619a9dcb88326a437ca51e68c2962