### PR TITLE
Add debug logging for vehicle seat occupancy checks

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -90,16 +90,38 @@ local function isAnySeatOccupied(veh)
     max = max - 1
   end
 
+  local found = false
+
   for seat = -1, max do
     local free = IsVehicleSeatFree(veh, seat)
+
+    if Config.Debug then
+      debugPrint(('veh %s seat %s free=%s'):format(veh, seat, tostring(free)))
+    end
+
     if free == false then
-      return true
+      if Config.Debug then
+        debugPrint(('veh %s seat %s occupied'):format(veh, seat))
+      end
+      found = true
+      break
     elseif free == nil then
       local ped = GetPedInVehicleSeat(veh, seat)
-      if ped and ped > 0 then return true end
+      if ped and ped > 0 then
+        if Config.Debug then
+          debugPrint(('veh %s seat %s occupied'):format(veh, seat))
+        end
+        found = true
+        break
+      end
     end
   end
-  return false
+
+  if Config.Debug then
+    debugPrint(('veh %s occupied=%s'):format(veh, tostring(found)))
+  end
+
+  return found
 end
 
 -- Limpia vehículos no streameados en el servidor


### PR DESCRIPTION
## Summary
- add seat-by-seat debug logs in `isAnySeatOccupied`
- report final vehicle occupancy decision

## Testing
- `luacheck --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6289efadc8326bfa72e7635d7040d