### PR TITLE
Fallback to four seats when seat data missing

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -90,6 +90,8 @@ local function isAnySeatOccupied(veh)
     max = max - 1
   end
 
+  if max == -1 then max = 3 end  -- assume up to four seats
+
   for seat = -1, max do
     if Config.Debug then
       local free = IsVehicleSeatFree(veh, seat)


### PR DESCRIPTION
## Summary
- Check up to four vehicle seats when seat data is unavailable to better detect occupants

## Testing
- `luacheck autotow/server.lua`
- `luac -p autotow/server.lua` *(fails: `luac: autotow/server.lua:130: '=' expected near 'continue'`)*

------
https://chatgpt.com/codex/tasks/task_e_68b633c3304c8326aa1fb40e1103aa1a