### PR TITLE
Improve seat occupancy logging in autotow

### DIFF
--- a/autotow/server.lua
+++ b/autotow/server.lua
@@ -93,13 +93,12 @@ local function isAnySeatOccupied(veh)
   if max == -1 then max = 3 end  -- assume up to four seats
 
   for seat = -1, max do
+    local ped = GetPedInVehicleSeat(veh, seat)
     if Config.Debug then
-      local free = IsVehicleSeatFree(veh, seat)
-      debugPrint(('veh %s seat %s free=%s'):format(veh, seat, tostring(free)))
+      debugPrint(('veh %s seat %s ped=%s'):format(veh, seat, ped or 'none'))
     end
 
-    local ped = GetPedInVehicleSeat(veh, seat)
-    if ped and ped > 0 then
+    if ped and ped ~= 0 then
       if Config.Debug then
         debugPrint(('veh %s seat %s occupied'):format(veh, seat))
       end


### PR DESCRIPTION
## Summary
- log ped ID for each seat when checking occupancy
- only flag seats as occupied when a non-zero ped is present

## Testing
- `luac -p autotow/server.lua`


------
https://chatgpt.com/codex/tasks/task_e_68b6350615c08326921a7f7b633d137a